### PR TITLE
chore(deps): weekly lockfile update

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -909,7 +909,7 @@ wheels = [
 
 [[package]]
 name = "ha-govee-led-ble"
-version = "2.1.12"
+version = "2.1.13"
 source = { virtual = "." }
 dependencies = [
     { name = "bleak" },


### PR DESCRIPTION
Downloading cpython-3.14.3-linux-x86_64-gnu (download) (34.4MiB)
 Downloaded cpython-3.14.3-linux-x86_64-gnu (download)
Using CPython 3.14.3
Resolved 169 packages in 296ms
Updated ha-govee-led-ble v2.1.12 -> v2.1.13
