### PR TITLE
chore(deps): weekly lockfile update

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "ha-govee-led-ble"
-version = "2.1.14"
+version = "2.1.15"
 source = { virtual = "." }
 dependencies = [
     { name = "bleak" },


### PR DESCRIPTION
Downloading cpython-3.14.3-linux-x86_64-gnu (download) (34.4MiB)
 Downloaded cpython-3.14.3-linux-x86_64-gnu (download)
Using CPython 3.14.3
Resolved 162 packages in 191ms
Updated ha-govee-led-ble v2.1.14 -> v2.1.15
