### PR TITLE
build: drop redundant pytest/pytest-asyncio/coverage pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "aiousbwatcher>=1.1.1",
-    "coverage>=7.10.6",
     "mypy>=1.15",
-    "pytest>=9.0.0",
-    "pytest-asyncio>=1.3.0",
     "pytest-homeassistant-custom-component>=0.13.316",
     "pyserial>=3.5",
     "ruff>=0.9",

--- a/uv.lock
+++ b/uv.lock
@@ -875,7 +875,7 @@ wheels = [
 
 [[package]]
 name = "ha-govee-led-ble"
-version = "2.1.29"
+version = "2.1.30"
 source = { virtual = "." }
 dependencies = [
     { name = "bleak" },
@@ -885,11 +885,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "aiousbwatcher" },
-    { name = "coverage" },
     { name = "mypy" },
     { name = "pyserial" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
 ]
@@ -903,11 +900,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiousbwatcher", specifier = ">=1.1.1" },
-    { name = "coverage", specifier = ">=7.10.6" },
     { name = "mypy", specifier = ">=1.15" },
     { name = "pyserial", specifier = ">=3.5" },
-    { name = "pytest", specifier = ">=9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13.316" },
     { name = "ruff", specifier = ">=0.9" },
 ]


### PR DESCRIPTION
These three test dependencies are exact-pinned by `pytest-homeassistant-custom-component` (the HA test stack):

- `pytest==9.0.0`
- `pytest-asyncio==1.3.0`
- `coverage==7.10.6`

Declaring them as direct dev dependencies has no resolver effect (PHCC's exact pins win) but causes Renovate to create misleading update PRs that cannot actually advance the version (#44 is an example — claims to bump pytest to 9.0.3 but produces a no-op diff because PHCC's pin blocks it).

After this change, pytest stack updates flow only via PHCC bumps, which is the correct model for HA integration test suites.

Verified locally: `uv lock` produces only the expected structural changes — no actual package version regressions.