### PR TITLE
build(renovate): group and auto-merge major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,39 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "labels": ["dependencies"],
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
   "timezone": "Australia/Sydney",
-  "schedule": ["before 7am on Monday"],
+  "schedule": [
+    "before 7am on Monday"
+  ],
   "automerge": true,
   "platformAutomerge": true,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 7am on Monday"],
+    "schedule": [
+      "before 7am on Monday"
+    ],
     "commitMessageAction": "upgrade"
   },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "groupName": "all non-major"
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "all major"
     }
   ],
   "commitMessagePrefix": "build(deps):"


### PR DESCRIPTION
Adds an `all major` packageRules entry so major-version dependency updates are grouped into a single PR (matching the existing `all non-major` group's shape) and can auto-merge alongside the rest of the weekly Monday batch.

Inherits `automerge: true` and `platformAutomerge: true` from the top-level config.

Part of the renovate canonical-config rollout across all repos.