### PR TITLE
build(deps): adopt shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,41 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "timezone": "Australia/Sydney",
-  "schedule": [
-    "before 7am on Monday"
-  ],
-  "automerge": true,
-  "platformAutomerge": true,
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": [
-      "before 7am on Monday"
-    ],
-    "commitMessageAction": "upgrade"
-  },
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "digest"
-      ],
-      "groupName": "all non-major"
-    },
-    {
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "all major"
-    }
-  ],
-  "commitMessagePrefix": "build(deps):",
-  "pinDigests": true
+  "extends": ["github>teh-hippo/common-repo-configs//renovate/slots/mon-0900.json5"]
 }


### PR DESCRIPTION
Replaces this repo's full Renovate configuration with a one-line extends of the shared preset at [teh-hippo/common-repo-configs](https://github.com/teh-hippo/common-repo-configs).

Slot for this repo: `renovate/slots/mon-0900.json5` (Monday 09:00 Sydney).

Policy and rationale are documented in the preset repository's README.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>