### PR TITLE
ci(validate): drop cron and vestigial branch triggers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,11 +2,9 @@ name: Validate
 
 on:
   push:
-    branches: [master, "copilot/**", "dependabot/**"]
+    branches: [master]
   pull_request:
     branches: [master]
-  schedule:
-    - cron: "26 6 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Drops the daily 06:xx UTC cron and removes `copilot/**` / `dependabot/**` from `push.branches`. PR + post-merge push cover all real cases.