### PR TITLE
ci: adopt uv sync --locked pattern

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,8 +41,9 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
-      - run: uv run ruff check .
-      - run: uv run ruff format --check .
+      - run: uv sync --locked
+      - run: uv run --no-sync ruff check .
+      - run: uv run --no-sync ruff format --check .
 
   mypy:
     name: Mypy
@@ -52,7 +53,8 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
-      - run: uv run mypy custom_components/ha_govee_led_ble tests
+      - run: uv sync --locked
+      - run: uv run --no-sync mypy custom_components/ha_govee_led_ble tests
 
   test:
     name: Test
@@ -62,5 +64,6 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.14"
-      - run: uv run coverage run -m pytest tests/ -v --tb=short
-      - run: uv run coverage report --include="custom_components/ha_govee_led_ble/*" --fail-under=90
+      - run: uv sync --locked
+      - run: uv run --no-sync coverage run -m pytest tests/ -v --tb=short
+      - run: uv run --no-sync coverage report --include="custom_components/ha_govee_led_ble/*" --fail-under=90

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,16 +3,18 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+uv sync --locked
+
 echo "=== Lint ==="
-uv run ruff check .
-uv run ruff format --check .
+uv run --no-sync ruff check .
+uv run --no-sync ruff format --check .
 
 echo "=== Mypy ==="
-uv run mypy custom_components/ha_govee_led_ble tests
+uv run --no-sync mypy custom_components/ha_govee_led_ble tests
 
 echo "=== Test + Coverage ==="
-uv run coverage run -m pytest tests/ -v --tb=short
-uv run coverage report --include="custom_components/ha_govee_led_ble/*" --fail-under=90
+uv run --no-sync coverage run -m pytest tests/ -v --tb=short
+uv run --no-sync coverage report --include="custom_components/ha_govee_led_ble/*" --fail-under=90
 
 echo ""
 echo "✅ All checks passed — safe to push."

--- a/uv.lock
+++ b/uv.lock
@@ -881,7 +881,7 @@ wheels = [
 
 [[package]]
 name = "ha-govee-led-ble"
-version = "2.1.35"
+version = "2.1.37"
 source = { virtual = "." }
 dependencies = [
     { name = "bleak" },


### PR DESCRIPTION
Replace plain `uv run` invocations with one `uv sync --locked` per CI job followed by `uv run --no-sync` per command.

## Why

- **Deterministic** - the installed env matches the committed lockfile exactly.
- **Drift-safe** - `--locked` fails loudly if `pyproject.toml` and `uv.lock` disagree, catching cases where a release version bump or manual edit forgets to re-run `uv lock`.

## What changed

- `.github/workflows/validate.yml` - lint/mypy/test jobs each gain an `uv sync --locked` step; subsequent commands use `uv run --no-sync`.
- `scripts/check.sh` - same pattern, so local preflight matches CI.
- `uv.lock` - one-line refresh for project version drift (2.1.35 → 2.1.37). The release workflow had been bumping `pyproject.toml` without re-locking; `--locked` surfaced this on the first run.

## Validation

- `bash scripts/check.sh` passes locally.
- Local negative test: bumping `pyproject.toml` without re-locking now fails `uv sync --locked` with exit 1 and a clear message.

## Out of scope

- Does **not** fix #59 (upstream HA `serialx` bug). Tracked separately.

This is the pilot for fleet-wide rollout to the 5 other HA repos.