### PR TITLE
ci(release): commit uv.lock from build_command via assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ version_variables = ["custom_components/ha_govee_led_ble/manifest.json:version"]
 build_command = "pip install uv && uv lock"
 commit_message = "chore(release): {version}"
 tag_format = "v{version}"
+assets = ["uv.lock"]
 
 [tool.semantic_release.commit_parser_options]
 patch_tags = ["fix", "perf", "build"]


### PR DESCRIPTION
## Problem

After adopting `uv sync --locked` in Validate, every release leaves master with `pyproject.toml` and `manifest.json` bumped to vX.Y.Z but `uv.lock` still at vX.Y.(Z-1). The next PR onto master then red-fails CI on `uv sync --locked` with a project-version drift error.

Root cause: `python-semantic-release` v10 only commits files declared in `version_toml`, `version_variables`, the changelog, and `assets`. Our `build_command` already runs `uv lock`, but because `uv.lock` is not in `assets`, the refreshed file is discarded after the build step.

## Fix

Add `assets = ["uv.lock"]` to `[tool.semantic_release]`. PSR's documented version flow is:

1. Write version files
2. Write changelog
3. Run `build_command` (our `pip install uv && uv lock`)
4. Commit version files + changelog + assets
5. Tag, push, release

So `uv lock` runs with the bumped project version already in `pyproject.toml`, and the refreshed `uv.lock` is included in the `chore(release):` commit.

## Validation

Ran a real PSR dry-run locally on this branch in a disposable worktree:

```
GITHUB_TOKEN=dummy semantic-release -vv version --patch --no-push --no-vcs-release --no-tag
```

Resulting `chore(release): 2.1.38` commit:

```
$ git show --name-only --format=fuller HEAD
...
    chore(release): 2.1.38

CHANGELOG.md
custom_components/ha_govee_led_ble/manifest.json
pyproject.toml
uv.lock
```

Verified:
- All three version markers (`pyproject.toml:project.version`, `manifest.json:version`, `uv.lock` project entry) cohere at the bumped version.
- `uv sync --locked` passes against the simulated release commit (no drift).

## Out of scope

Several adjacent release.yml correctness improvements surfaced during review (release `concurrency: cancel-in-progress: false`, checkout `ref: workflow_run.head_sha`, `target_commitish: steps.semantic_release.outputs.commit_sha`). Tracking separately to keep this PR focused on the drift fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>