### PR TITLE
chore(renovate): extend base preset directly (retire weekly slot)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>teh-hippo/common-repo-configs//renovate/slots/mon-0900.json5"]
+  "extends": ["github>teh-hippo/common-repo-configs//renovate/default.json5"]
 }


### PR DESCRIPTION
Retires the weekly `mon-0900` staggering slot and points `renovate.json` at the shared base preset (`renovate/default.json5`).

The slots were a free-tier concurrency precaution and are now obsolete: auto-merge makes timing irrelevant and excess CI jobs queue rather than fail. Routine updates now flow continuously, still auto-merged on green. The daily lock-file relock and immediate vulnerability lane are unchanged (they live in the base preset).