### PR TITLE
ci(release): enable the segments beta channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: [Validate]
     types: [completed]
-    branches: [master]
+    branches: [master, segments]
 
 concurrency:
   group: release
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,11 @@ other_allowed_tags = ["chore", "ci", "docs", "style", "refactor", "test"]
 match = "master"
 prerelease = false
 
+[tool.semantic_release.branches.beta]
+match = "segments"
+prerelease = true
+prerelease_token = "beta"
+
 [tool.semantic_release.changelog]
 mode = "init"
 


### PR DESCRIPTION
Enables HACS beta previews from the `segments` branch using the standard python-semantic-release multibranch setup.

## What this does
- Adds a `[tool.semantic_release.branches.beta]` group matching `segments` (prerelease token `beta`), so commits there compute `vX.Y.Z-beta.N`.
- Lets the Release workflow run for `segments` (`workflow_run.branches`) and checks out the run's `head_branch`, so semantic-release runs against the branch that passed Validate rather than the default branch.

## Why it lives on master
GitHub only runs `workflow_run` automation from the default branch, so the multibranch release config must be on `master` to take effect. This is CI-only; no feature code lands on master, which stays the stable channel. The `latest` alias step already skips prereleases.

## Result
Once merged, a push to `segments` that passes Validate cuts a `beta` GitHub pre-release. HACS surfaces it only to users who enable **Show beta versions**.