### PR TITLE
fix: keep the StaticPathConfig import valid on Home Assistant 2026.8

### DIFF
--- a/custom_components/ha_govee_led_ble/__init__.py
+++ b/custom_components/ha_govee_led_ble/__init__.py
@@ -3,7 +3,12 @@
 from pathlib import Path
 
 from homeassistant.components import frontend
-from homeassistant.components.http import StaticPathConfig
+
+# Home Assistant 2026.8 moved StaticPathConfig into homeassistant.components.http.server and
+# re-exports it from the package root without an explicit export, which strict mypy rejects.
+# The submodule does not exist in 2026.7, so importing from it directly would break at runtime.
+# unused-ignore keeps the comment valid on versions where the import still type checks cleanly.
+from homeassistant.components.http import StaticPathConfig  # type: ignore[attr-defined, unused-ignore]
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## What broke

The `Mypy` check on Renovate PR #108 (`chore(deps): lock file maintenance`) fails:

```
custom_components/ha_govee_led_ble/__init__.py:6: error: Module "homeassistant.components.http" does not explicitly export attribute "StaticPathConfig"  [attr-defined]
Found 1 error in 1 file (checked 62 source files)
```

## Why

That PR moves `homeassistant` from 2026.7.2 to 2026.8.0b3. In 2026.7.2 `StaticPathConfig` is defined directly in `homeassistant/components/http/__init__.py`. In 2026.8.0b3 it lives in the new `homeassistant/components/http/server.py` and the package root only re-exports it with a bare `# noqa: F401` import, with no `__all__` entry and no `as` form. Our mypy config is `strict`, which implies `--no-implicit-reexport`, so the package-root import is no longer an explicit export.

Importing straight from `homeassistant.components.http.server` is not an option on `master`: that module does not exist in 2026.7.2, which the current lock file resolves to, so the integration would fail to import at runtime and take the `Test` job with it.

## What changed

One import in `custom_components/ha_govee_led_ble/__init__.py` keeps the documented package-root path and carries `# type: ignore[attr-defined, unused-ignore]`, with a comment explaining the version split. The `unused-ignore` code is what makes it work on both versions: without it, 2026.7.2 reports `Unused "type: ignore" comment  [unused-ignore]` because `strict` also implies `--warn-unused-ignores`. The ignore falls away on its own if upstream restores an explicit re-export.

## Evidence

Command is the one CI runs: `uv run --no-sync mypy custom_components/ha_govee_led_ble tests`.

With the 2026.8.0b3 lock file from PR #108:

- before: `custom_components/ha_govee_led_ble/__init__.py:6: error: Module "homeassistant.components.http" does not explicitly export attribute "StaticPathConfig"  [attr-defined]` / `Found 1 error in 1 file (checked 62 source files)`
- after: `Success: no issues found in 62 source files`

With this branch's lock file (2026.7.2): `Success: no issues found in 62 source files`, and `bash scripts/check.sh` passes end to end (Lint, Kaitai, Mypy, 849 tests, 98% coverage). The full suite also passes against 2026.8.0b3.