### PR TITLE
feat!: document the native v6 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,17 @@ Local BLE control of supported Govee LED strips from Home Assistant, with no clo
 
 All models support on/off, brightness, RGB color, color temperature, and state readback.
 
-- **H617A**: LED Strip · 80+ scenes · music mode
-- **H6199**: DreamView T1 · video & music modes · advanced controls
+- **H617A**: LED Strip · 83 scenes · 11 music modes
+- **H6199**: DreamView T1 · 240 scenes · video and music modes · advanced controls
+
+## Version 6 migration
+
+Version 6 replaces the custom frontend and parallel mode controls with Home Assistant's native light effect selector.
+Effect families are configured from the integration options. H617A enables Scenes and Music by default, while H6199
+enables Video by default.
+
+Timers, saved custom effects, the active-mode sensor and the old mode services have been removed. Segment painting
+remains available through the `paint_segments`, `set_segment_color` and `set_segment_brightness` entity services.
 
 ## Installation
 
@@ -42,7 +51,8 @@ To add manually in Home Assistant:
 
 ## Dashboards
 
-Example stock Lovelace dashboards live in [`docs/dashboards/`](docs/dashboards/). Segment painting uses the bundled `custom:govee-led-ble-card`, not these.
+Example stock Lovelace dashboards live in [`docs/dashboards/`](docs/dashboards/). The integration uses standard Home
+Assistant light controls and effect selectors.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- document the Version 6 Home Assistant migration
- replace the stale custom-card dashboard guidance with native effect selector guidance
- record the retained grouped segment services

BREAKING CHANGE: Version 6 removes timers, saved custom effects, the custom frontend, active-mode sensor, parallel mode controls and retired mode services.
