### PR TITLE
fix(protocol): preserve 16-bit DIY codes

### DIFF
--- a/custom_components/ha_govee_led_ble/coordinator.py
+++ b/custom_components/ha_govee_led_ble/coordinator.py
@@ -66,7 +66,7 @@ _CORE_STATE_FIELDS = (
     "rgb_color",
     "color_temp_kelvin",
     "effect",
-    "diy_slot",
+    "diy_code",
 )
 _COLOR_MODE_FIELDS = (
     "video_full_screen",
@@ -108,7 +108,7 @@ def _expected_color_mode_from_generated(
     mode = getattr(generated.body.sub, "name", None)
     detail = generated.body.sub_body
     if mode == "diy":
-        return ParsedMode.DIY, int(detail.slot)
+        return ParsedMode.DIY, int(detail.code)
     if mode == "music":
         return ParsedMode.MUSIC, None
     if mode == "scene":
@@ -254,7 +254,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         self.hw_version: str | None = None
         self.music_mode = "off"
         self.video_mode = "off"
-        self.diy_slot: int | None = None
+        self.diy_code: int | None = None
         self.color_mode: ParsedMode | None = None
         self._scene_code: int | None = None
         self.scene_speed_scene_code: int | None = None
@@ -520,7 +520,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
     ) -> tuple[str, ...]:
         parsed = parse_generated_color_mode(generated, self.model)
         if parsed.mode is ParsedMode.DIY:
-            mode_detail = parsed.diy_slot
+            mode_detail = parsed.diy_code
         else:
             mode_detail = None
         observed_color_mode = parsed.mode, mode_detail
@@ -541,7 +541,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             if parsed.music_mode is not None and self._accept_expected("music_mode", parsed.music_mode):
                 self.music_mode = parsed.music_mode
                 self.video_mode, self.effect = "off", None
-                self.diy_slot = None
+                self.diy_code = None
                 observed.append("music_mode")
             else:
                 accept_parameters = False
@@ -549,7 +549,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             if parsed.video_mode is not None and self._accept_expected("video_mode", parsed.video_mode):
                 self.video_mode = parsed.video_mode
                 self.music_mode, self.effect = "off", None
-                self.diy_slot = None
+                self.diy_code = None
                 observed.append("video_mode")
             else:
                 accept_parameters = False
@@ -557,7 +557,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             if self._accept_expected("effect", None):
                 self.effect = None
                 self.music_mode = self.video_mode = "off"
-                self.diy_slot = parsed.diy_slot
+                self.diy_code = parsed.diy_code
                 observed.append("effect")
             else:
                 accept_parameters = False
@@ -565,17 +565,17 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             if self._accept_expected("effect", scene_effect):
                 self.effect = scene_effect
                 self.music_mode, self.video_mode = "off", "off"
-                self.diy_slot = None
+                self.diy_code = None
                 self._sync_scene_speed(scene_effect)
                 observed.append("effect")
         elif parsed.mode is ParsedMode.COLOUR:
             if self._accept_expected("effect", None):
                 self.effect, self.music_mode, self.video_mode = None, "off", "off"
-                self.diy_slot = None
+                self.diy_code = None
                 observed.append("effect")
         else:
             self.effect = None
-            self.diy_slot = None
+            self.diy_code = None
             self.music_mode = self.video_mode = "off"
             observed.append("effect")
         if accept_parameters:

--- a/custom_components/ha_govee_led_ble/coordinator_base.py
+++ b/custom_components/ha_govee_led_ble/coordinator_base.py
@@ -36,7 +36,7 @@ class _CoordinatorBase(DataUpdateCoordinator[dict[str, Any]]):
     music_sensitivity: int
     music_color: tuple[int, int, int] | None
     music_calm: bool
-    diy_slot: int | None
+    diy_code: int | None
     color_mode: ParsedMode | None
     scene_speed_scene_code: int | None
     scene_speed_index: int | None

--- a/custom_components/ha_govee_led_ble/coordinator_modes.py
+++ b/custom_components/ha_govee_led_ble/coordinator_modes.py
@@ -59,7 +59,7 @@ class _ActiveModeMixin(_CoordinatorBase):
     def active_mode(self) -> str:
         if not self.is_on:
             return "off"
-        if self.diy_slot is not None:
+        if self.diy_code is not None:
             return "custom"
         if self.effect in self.scene_name_set:
             return "scene"
@@ -146,7 +146,7 @@ class _ActiveModeMixin(_CoordinatorBase):
     def _enter_static_mode(self) -> None:
         """Clear every non-static mode so exactly one operating mode is active."""
         self.effect = None
-        self.diy_slot = None
+        self.diy_code = None
         self.music_mode = self.video_mode = "off"
 
     async def async_select_music_slug(self, slug: str) -> None:
@@ -176,7 +176,7 @@ class _ActiveModeMixin(_CoordinatorBase):
                 await self.send_command(packet)
         self.music_mode, self.video_mode = slug, "off"
         self.effect = None
-        self.diy_slot = None
+        self.diy_code = None
 
     async def async_restore_pre_mode(self) -> None:
         snap = self._pre_mode_snapshot

--- a/custom_components/ha_govee_led_ble/diagnostics.py
+++ b/custom_components/ha_govee_led_ble/diagnostics.py
@@ -65,7 +65,7 @@ async def async_get_config_entry_diagnostics(
         "scene_speed_position": (
             coordinator.scene_speed_index + 1 if coordinator.scene_speed_index is not None else None
         ),
-        "diy_slot": coordinator.diy_slot,
+        "diy_code": coordinator.diy_code,
         "color_mode": coordinator.color_mode.name.lower() if coordinator.color_mode is not None else None,
         "video_saturation": coordinator.video_saturation,
         "video_sound_effects": coordinator.video_sound_effects,

--- a/custom_components/ha_govee_led_ble/generated_protocol/govee_common.py
+++ b/custom_components/ha_govee_led_ble/generated_protocol/govee_common.py
@@ -88,8 +88,7 @@ class GoveeCommon(ReadWriteKaitaiStruct):
             self._root = _root
 
         def _read(self):
-            self.slot = self._io.read_u1()
-            self.type_byte = self._io.read_u1()
+            self.code = self._io.read_u2le()
             self._dirty = False
 
 
@@ -99,8 +98,7 @@ class GoveeCommon(ReadWriteKaitaiStruct):
 
         def _write__seq(self, io=None):
             super(GoveeCommon.DiySelector, self)._write__seq(io)
-            self._io.write_u1(self.slot)
-            self._io.write_u1(self.type_byte)
+            self._io.write_u2le(self.code)
 
 
         def _check(self):

--- a/custom_components/ha_govee_led_ble/light.py
+++ b/custom_components/ha_govee_led_ble/light.py
@@ -124,7 +124,7 @@ _STATE_FIELDS = (
     "is_on brightness_pct rgb_color color_temp_kelvin effect video_saturation "
     "segment_colors video_full_screen video_sound_effects video_sound_effects_softness "
     "white_brightness music_sensitivity "
-    "music_calm music_color diy_slot music_mode video_mode"
+    "music_calm music_color diy_code music_mode video_mode"
 ).split()
 
 
@@ -253,7 +253,7 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
             return
         if (
             coordinator.effect is not None
-            or coordinator.diy_slot is not None
+            or coordinator.diy_code is not None
             or coordinator.music_mode != "off"
             or coordinator.video_mode != "off"
         ):
@@ -307,7 +307,7 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
             return
         if coordinator.color_mode not in (None, ParsedMode.COLOUR):
             return
-        if coordinator.music_mode != "off" or coordinator.video_mode != "off" or coordinator.diy_slot is not None:
+        if coordinator.music_mode != "off" or coordinator.video_mode != "off" or coordinator.diy_code is not None:
             return
         if coordinator.effect is not None:
             return
@@ -391,7 +391,7 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
             for packet in _scene_packets(coordinator.profile, scene, speed_index=speed_index):
                 await coordinator.send_command(packet)
             coordinator.effect = key
-            coordinator.diy_slot = None
+            coordinator.diy_code = None
             coordinator.music_mode = coordinator.video_mode = "off"
             coordinator._sync_scene_speed(key, speed_index=speed_index)
             return

--- a/custom_components/ha_govee_led_ble/light_services.py
+++ b/custom_components/ha_govee_led_ble/light_services.py
@@ -130,7 +130,7 @@ class _GoveeLightServicesMixin(_GoveeLightOwner):
             )
             c.video_mode, c.effect = mode, None
             c.music_mode = "off"
-            c.diy_slot = None
+            c.diy_code = None
             c.video_saturation, c.video_full_screen = saturation, resolved_fs
             c.video_sound_effects = resolved_sound
             if supports_sound:

--- a/custom_components/ha_govee_led_ble/protocol.py
+++ b/custom_components/ha_govee_led_ble/protocol.py
@@ -636,7 +636,7 @@ def build_music_params_a3(
 
 
 class ParsedMode(Enum):
-    """Operating mode from a colour-mode reply; DIY carries a slot, music and video their own state."""
+    """Operating mode from a colour-mode reply; DIY carries a code, music and video their own state."""
 
     UNKNOWN = auto()
     COLOUR = auto()
@@ -651,7 +651,7 @@ class ParsedColorModeResponse:
     mode: ParsedMode = ParsedMode.UNKNOWN
     effect: str | None = None
     scene_code: int | None = None
-    diy_slot: int | None = None
+    diy_code: int | None = None
     music_mode: str | None = None
     video_mode: str | None = None
     video_full_screen: bool | None = None
@@ -720,7 +720,7 @@ def parse_generated_color_mode(
     if mode == COLOR_MODE_DIY:
         return ParsedColorModeResponse(
             mode=ParsedMode.DIY,
-            diy_slot=int(body.mode_body.slot),
+            diy_code=int(body.mode_body.code),
         )
     if mode == COLOR_MODE_MUSIC:
         detail = body.mode_body

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def _make_coord(**ov) -> MagicMock:
         music_calm=False,
         music_color=None,
         segment_colors=[(255, 255, 255)] * 15,
-        diy_slot=None,
+        diy_code=None,
         color_mode=None,
         scene_speed_scene_code=None,
         scene_speed_index=None,
@@ -90,7 +90,7 @@ def _make_coord(**ov) -> MagicMock:
 
     def _enter_static_mode() -> None:
         c.effect = None
-        c.diy_slot = None
+        c.diy_code = None
         c.music_mode = c.video_mode = "off"
 
     c._enter_static_mode = MagicMock(side_effect=_enter_static_mode)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -39,7 +39,7 @@ def _c(**kw):
 async def test_initial_state_and_update(coord, h6199):
     assert (coord.is_on, coord.brightness_pct, coord.rgb_color) == (False, 100, (255, 255, 255))
     assert coord.effect is None and coord.address == "AA:BB:CC:DD:EE:FF" and coord.model == "H617A"
-    assert (coord.music_mode, coord.video_mode, coord.diy_slot) == ("off", "off", None)
+    assert (coord.music_mode, coord.video_mode, coord.diy_code) == ("off", "off", None)
     assert coord.color_mode is None
     assert coord.profile == MODEL_PROFILES["H617A"] and coord.profile.state_readable
     assert coord.profile.supports_music_mode and not coord.profile.supports_video_mode
@@ -52,7 +52,7 @@ async def test_initial_state_and_update(coord, h6199):
         "rgb_color": (255, 0, 128),
         "color_temp_kelvin": None,
         "effect": None,
-        "diy_slot": None,
+        "diy_code": None,
     }
     with (
         patch.object(coord, "_ensure_connected", new_callable=AsyncMock),
@@ -467,6 +467,41 @@ def test_readback_mode_mutual_exclusion(h6199):
     )
 
 
+def test_diy_readback_retains_complete_code(coord):
+    coord.is_on = True
+    coord._notify_callback(
+        None,
+        bytearray(proto.build_packet(0xAA, 0x05, [proto.COLOR_MODE_DIY, 0x84, 0x03])),
+    )
+
+    assert coord.color_mode is proto.ParsedMode.DIY
+    assert coord.active_mode == "custom"
+    assert coord.diy_code == 900
+
+
+async def test_diy_command_expectation_rejects_truncated_readback(coord):
+    command = proto.build_packet(0x33, 0x05, [proto.COLOR_MODE_DIY, 0x20, 0x03])
+    client = _c(write_gatt_char=AsyncMock())
+    with patch.object(coord, "_ensure_connected", return_value=client):
+        await coord.send_command(command)
+
+    assert coord._expected_state["color_mode"][0] == (proto.ParsedMode.DIY, 800)
+
+    coord._notify_callback(
+        None,
+        bytearray(proto.build_packet(0xAA, 0x05, [proto.COLOR_MODE_DIY, 0x20, 0x00])),
+    )
+    assert coord.color_mode is None
+    assert coord.diy_code is None
+
+    coord._notify_callback(
+        None,
+        bytearray(proto.build_packet(0xAA, 0x05, [proto.COLOR_MODE_DIY, 0x20, 0x03])),
+    )
+    assert coord.color_mode is proto.ParsedMode.DIY
+    assert coord.diy_code == 800
+
+
 async def test_send_command_arms_expected_state(coord, h6199):
     c = _c(write_gatt_char=AsyncMock())
     with patch.object(coord, "_ensure_connected", return_value=c):
@@ -533,14 +568,14 @@ def test_scene_expectation_rejects_delayed_same_mode_reply(h6199):
 
 def test_unknown_mode_clears_restored_metadata(h6199):
     h6199.effect = "Flame"
-    h6199.diy_slot = 0xF0
+    h6199.diy_code = 0xF0
     h6199.music_mode, h6199.video_mode = "rhythm", "movie"
 
     h6199._notify_callback(None, bytearray(proto.build_packet(0xAA, 0x05, [0x99, 0x01])))
 
     assert h6199.color_mode is proto.ParsedMode.UNKNOWN
     assert h6199.effect is None
-    assert h6199.diy_slot is None
+    assert h6199.diy_code is None
     assert (h6199.music_mode, h6199.video_mode) == ("off", "off")
 
 
@@ -1037,6 +1072,9 @@ def test_expectations_from_packet_covers_every_command_family():
     assert _expectations_from_packet(proto.build_white_brightness(80))["white_brightness"] == 80
 
     assert _expectations_from_packet(proto.build_scene(scene_code))["effect"] == proto.SCENE_EFFECT_BY_ID[scene_code]
+
+    diy = _expectations_from_packet(proto.build_packet(0x33, 0x05, [proto.COLOR_MODE_DIY, 0x20, 0x03]))
+    assert diy["color_mode"] == (proto.ParsedMode.DIY, 800)
 
     rhythm = _expectations_from_packet(
         proto.build_music_mode_with_color(rhythm_id, sensitivity=50, color=(10, 20, 30), calm=True)

--- a/tests/test_coordinator_modes.py
+++ b/tests/test_coordinator_modes.py
@@ -25,7 +25,7 @@ def _sent(sc):
 
 async def test_select_music_slug_sends_power_then_music_and_sets_state(coord):
     coord.is_on, coord.effect = True, "prior effect"
-    coord.diy_slot = 0xF0
+    coord.diy_code = 0xF0
     with patch.object(coord, "send_command", new_callable=AsyncMock) as sc:
         await coord.async_select_music_slug("rhythm")
     assert _sent(sc) == [
@@ -35,7 +35,7 @@ async def test_select_music_slug_sends_power_then_music_and_sets_state(coord):
     assert coord.is_on is True
     assert (coord.music_mode, coord.video_mode) == ("rhythm", "off")
     assert coord.effect is None
-    assert coord.diy_slot is None
+    assert coord.diy_code is None
 
 
 async def test_h6199_music_reapply_preserves_fixed_colour(h6199):
@@ -136,13 +136,13 @@ async def test_restore_pre_mode_re_emits_matching_builder(coord, snapshot, expec
     coord._pre_mode_snapshot = snapshot
     coord.music_mode, coord.video_mode = "rhythm", "movie"
     coord.effect = "leftover"
-    coord.diy_slot = 0xF0
+    coord.diy_code = 0xF0
     with patch.object(coord, "send_command", new_callable=AsyncMock) as sc:
         await coord.async_restore_pre_mode()
     assert _sent(sc) == [expected]
     assert (coord.music_mode, coord.video_mode) == ("off", "off")
     assert coord.effect is None
-    assert coord.diy_slot is None
+    assert coord.diy_code is None
 
 
 async def test_select_off_routes_to_restore_and_clears_music_mode(coord):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -33,7 +33,7 @@ async def test_surfaces_segment_fields(mock_h6199_coordinator):
     assert coord["supports_segments"] is True
     assert coord["segment_count"] == 15
     assert coord["segment_colors"] == colors
-    assert coord["diy_slot"] is None
+    assert coord["diy_code"] is None
     assert coord["color_mode"] is None
 
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -134,13 +134,13 @@ async def test_turn_on_scene_applies_and_clears_sticky(light, mock_coordinator):
     co = mock_coordinator
     co.is_on = True
     co.music_mode, co.video_mode = "rhythm", "off"
-    co.diy_slot = 0xF0
+    co.diy_code = 0xF0
     await light.async_turn_on(effect="rainbow")
     sent = [call.args[0] for call in co.send_command.call_args_list]
     scene = SCENES["rainbow"]
     assert sent == proto.build_scene_multi(scene.param, scene.code, scene.scene_type)
     assert co.effect == "rainbow"
-    assert co.diy_slot is None
+    assert co.diy_code is None
     assert co.music_mode == "off" and co.video_mode == "off"
 
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -699,10 +699,22 @@ def test_static_readback_carries_no_colour():
         assert parsed.rgb_color is None and parsed.white_brightness is None
 
 
-def test_parse_direct_diy_slot_readback():
+def test_parse_direct_diy_code_readback():
     parsed = _parse_color(bytes([0x0A, 0xF0]))
     assert parsed.mode is proto.ParsedMode.DIY
-    assert parsed.diy_slot == 0xF0
+    assert parsed.diy_code == 0xF0
+
+    parsed = _parse_color(bytes([0x0A, 0x20, 0x03]))
+    assert parsed.mode is proto.ParsedMode.DIY
+    assert parsed.diy_code == 800
+
+
+def test_describe_diy_uses_complete_code():
+    command = (ROOT / "tools/ble/kaitai/src/command_write_diy_saved.bin").read_bytes()
+    status = (ROOT / "tools/ble/kaitai/src/status_reply_cm_diy_saved.bin").read_bytes()
+
+    assert describe_generated(command, "TX", "H617A") == "diy code=800 (0x0320)"
+    assert describe_generated(status, "RX", "H617A") == "reply colour_mode=diy code=900 (0x0384)"
 
 
 def test_parse_music_calm_only_for_rhythm():

--- a/tools/ble/generated_protocol_view.py
+++ b/tools/ble/generated_protocol_view.py
@@ -193,7 +193,7 @@ def _format_h617a_command(root: Any) -> str | None:
     if sub == "scene":
         return f"scene id={int(detail.code)}"
     if sub == "diy":
-        return f"diy slot={int(detail.slot):#04x} type={int(detail.type_byte):#04x}"
+        return f"diy code={int(detail.code)} ({int(detail.code):#06x})"
     if sub == "music":
         colour = _rgb(detail.rgb) if detail.manual_color_count else "auto"
         return f"music {_named(detail.mode_id)} sensitivity={int(detail.sensitivity)} colour={colour}"
@@ -297,7 +297,7 @@ def _format_h617a_status(root: Any) -> str | None:
     if mode == "scene":
         return f"reply colour_mode=scene id={int(detail.scene_id)}"
     if mode == "diy":
-        return f"reply colour_mode=diy slot={int(detail.slot):#04x} type={int(detail.type_byte):#04x}"
+        return f"reply colour_mode=diy code={int(detail.code)} ({int(detail.code):#06x})"
     if mode == "music":
         colour = _rgb(detail.rgb) if detail.manual_color_count else "auto"
         return (

--- a/tools/ble/kaitai/govee_common.ksy
+++ b/tools/ble/kaitai/govee_common.ksy
@@ -15,10 +15,8 @@ types:
           min: 2
   diy_selector:
     seq:
-      - id: slot
-        type: u1
-      - id: type_byte
-        type: u1
+      - id: code
+        type: u2le
   music_selector:
     seq:
       - id: mode_id

--- a/tools/ble/kaitai/spec/command_write_diy_saved.kst
+++ b/tools/ble/kaitai/spec/command_write_diy_saved.kst
@@ -12,8 +12,6 @@ provenance:
 asserts:
 - actual: body.sub
   expected: 10
-- actual: body.sub_body.slot
-  expected: 32
-- actual: body.sub_body.type_byte
-  expected: 3
+- actual: body.sub_body.code
+  expected: 800
 fixture_sha256: d746f1faf539e2775896740100522a5f212125ee308ebc938e8eac817a33337e

--- a/tools/ble/kaitai/spec/status_reply_cm_diy_saved.kst
+++ b/tools/ble/kaitai/spec/status_reply_cm_diy_saved.kst
@@ -12,8 +12,6 @@ asserts:
   expected: 5
 - actual: body.mode
   expected: 10
-- actual: body.mode_body.slot
-  expected: 132
-- actual: body.mode_body.type_byte
-  expected: 3
+- actual: body.mode_body.code
+  expected: 900
 fixture_sha256: 4b80f383403c4e91ba473c843e8f0e916e7a4cb51dbfebbbbc7e577c4c4ae4c6


### PR DESCRIPTION
## Summary

- model the H617A DIY selector as one little-endian 16-bit code
- retain the complete code through command expectations, readback state and diagnostics
- update protocol tooling and add regressions for codes above 255

## Review

The retained command and status fixtures decode as codes 800 and 900. The previous schema split each value into two bytes and runtime state discarded the high byte. The implementation and a post-change review found no H6199 impact because that model does not use the shared H617A DIY selector.

## Validation

- `bash scripts/check.sh`
- high-byte command expectation and readback mismatch coverage
- H617A command and status decoder output coverage

Fixes #150
