### PR TITLE
fix(frontend): preserve device editor route on rollback

### DIFF
--- a/custom_components/ha_govee_led_ble/__init__.py
+++ b/custom_components/ha_govee_led_ble/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     resolve_model,
 )
 from .coordinator import GoveeBLECoordinator
+from .editor import async_register_editor_panel, editor_url
 
 type GoveeBLEConfigEntry = ConfigEntry[GoveeBLECoordinator]
 
@@ -71,6 +72,7 @@ def _unsupported_model_issue_id(entry: GoveeBLEConfigEntry) -> str:
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    await async_register_editor_panel(hass)
     return True
 
 
@@ -187,6 +189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoveeBLEConfigEntry) -> 
         hass,
         entry.unique_id,
         model,
+        configuration_url=editor_url(entry.entry_id),
         effect_families=effect_families_from_options(model, entry.options),
     )
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/ha_govee_led_ble/coordinator.py
+++ b/custom_components/ha_govee_led_ble/coordinator.py
@@ -226,6 +226,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         address: str,
         model: str,
         *,
+        configuration_url: str,
         effect_families: frozenset[str] | None = None,
     ) -> None:
         profile = get_profile(model)
@@ -236,6 +237,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             update_interval=timedelta(seconds=30) if profile.state_readable else None,
         )
         self.address, self.model, self.profile = address, model, profile
+        self.configuration_url = configuration_url
         self.effect_families = default_effect_families(model) if effect_families is None else effect_families
         self._client: BleakClient | None = None
         self._lock = asyncio.Lock()
@@ -298,6 +300,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             name=f"Govee {self.model}",
             manufacturer="Govee",
             model=self.model,
+            configuration_url=self.configuration_url,
             sw_version=self.fw_version,
             hw_version=self.hw_version,
         )

--- a/custom_components/ha_govee_led_ble/editor.py
+++ b/custom_components/ha_govee_led_ble/editor.py
@@ -1,0 +1,46 @@
+"""Stable frontend route contract for per-device configuration."""
+
+from pathlib import Path
+
+from homeassistant.components import frontend
+from homeassistant.components.http.server import StaticPathConfig
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+EDITOR_PANEL_PATH = "ha-govee-led-ble"
+EDITOR_ROUTE_SEGMENT = "editor"
+EDITOR_ELEMENT_NAME = "ha-govee-led-ble-editor"
+EDITOR_STATIC_URL = f"/{DOMAIN}_static"
+EDITOR_MODULE_URL = f"{EDITOR_STATIC_URL}/editor.js"
+_EDITOR_STATIC_PATH = Path(__file__).parent / "frontend"
+
+
+def editor_url(config_entry_id: str) -> str:
+    """Return the canonical internal editor URL for a config entry."""
+    return f"homeassistant://{EDITOR_PANEL_PATH}/{EDITOR_ROUTE_SEGMENT}/{config_entry_id}"
+
+
+async def async_register_editor_panel(hass: HomeAssistant) -> None:
+    """Register the stable hidden panel served by the device configuration link."""
+    await hass.http.async_register_static_paths(
+        [StaticPathConfig(EDITOR_STATIC_URL, str(_EDITOR_STATIC_PATH), cache_headers=False)]
+    )
+    if frontend.async_panel_exists(hass, EDITOR_PANEL_PATH):
+        return
+    frontend.async_register_built_in_panel(
+        hass,
+        component_name="custom",
+        frontend_url_path=EDITOR_PANEL_PATH,
+        config={
+            "configuration_path": f"/config/integrations/integration/{DOMAIN}",
+            "_panel_custom": {
+                "name": EDITOR_ELEMENT_NAME,
+                "module_url": EDITOR_MODULE_URL,
+                "embed_iframe": False,
+                "trust_external": False,
+            },
+        },
+        require_admin=True,
+        show_in_sidebar=False,
+    )

--- a/custom_components/ha_govee_led_ble/frontend/editor.js
+++ b/custom_components/ha_govee_led_ble/frontend/editor.js
@@ -1,0 +1,63 @@
+class GoveeLedBleEditor extends HTMLElement {
+  connectedCallback() {
+    this._render();
+  }
+
+  set panel(value) {
+    this._panel = value;
+    this._render();
+  }
+
+  _render() {
+    if (!this.isConnected || !this._panel) {
+      return;
+    }
+
+    const configurationPath =
+      this._panel.config?.configuration_path ??
+      "/config/integrations/integration/ha_govee_led_ble";
+
+    this.innerHTML = `
+      <style>
+        :host {
+          display: block;
+          padding: 24px;
+        }
+
+        ha-card {
+          margin: 0 auto;
+          max-width: 640px;
+          padding: 24px;
+        }
+
+        h1 {
+          font-size: 24px;
+          margin: 0 0 16px;
+        }
+
+        p {
+          line-height: 1.5;
+          margin: 0 0 24px;
+        }
+
+        a {
+          color: var(--primary-color);
+          font-weight: 500;
+        }
+      </style>
+      <ha-card>
+        <h1>Govee LED BLE configuration</h1>
+        <p>
+          Advanced effect editing is not available in this version. You can
+          continue managing the integration through Home Assistant.
+        </p>
+        <a>Open integration configuration</a>
+      </ha-card>
+    `;
+    this.querySelector("a").href = configurationPath;
+  }
+}
+
+if (!customElements.get("ha-govee-led-ble-editor")) {
+  customElements.define("ha-govee-led-ble-editor", GoveeLedBleEditor);
+}

--- a/custom_components/ha_govee_led_ble/manifest.json
+++ b/custom_components/ha_govee_led_ble/manifest.json
@@ -32,7 +32,8 @@
     ],
     "config_flow": true,
     "dependencies": [
-        "bluetooth_adapters"
+        "bluetooth_adapters",
+        "http"
     ],
     "documentation": "https://github.com/teh-hippo/ha-govee-led-ble",
     "integration_type": "device",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,11 @@ def _make_coord(**ov) -> MagicMock:
     c._enter_static_mode = MagicMock(side_effect=_enter_static_mode)
     type(c).device_info = PropertyMock(
         return_value=DeviceInfo(
-            identifiers={(DOMAIN, d["address"])}, name=f"Govee {d['model']}", manufacturer="Govee", model=d["model"]
+            identifiers={(DOMAIN, d["address"])},
+            name=f"Govee {d['model']}",
+            manufacturer="Govee",
+            model=d["model"],
+            configuration_url="homeassistant://ha-govee-led-ble/editor/test-entry",
         )
     )
     return c

--- a/tests/mock_ble.py
+++ b/tests/mock_ble.py
@@ -22,6 +22,7 @@ from tools.ble.mock_ble.mock_device import RGB, FakeGoveeClient, GoveeDeviceSim
 
 _COORDINATOR = "custom_components.ha_govee_led_ble.coordinator"
 TEST_ADDRESS = "AA:BB:CC:DD:EE:FF"
+TEST_CONFIGURATION_URL = "homeassistant://ha-govee-led-ble/editor/test-entry"
 MODELS = ("H617A", "H6199")
 
 
@@ -72,7 +73,7 @@ class MockBle:
 async def mock_ble_fixture(request, hass) -> AsyncIterator[MockBle]:
     model = request.param
     sim = GoveeDeviceSim(model)
-    coordinator = GoveeBLECoordinator(hass, TEST_ADDRESS, model)
+    coordinator = GoveeBLECoordinator(hass, TEST_ADDRESS, model, configuration_url=TEST_CONFIGURATION_URL)
     with patch_transport(sim) as client:
         yield MockBle(sim=sim, coordinator=coordinator, client=client)
         await coordinator.disconnect()
@@ -82,7 +83,7 @@ async def mock_ble_fixture(request, hass) -> AsyncIterator[MockBle]:
 @pytest.fixture(name="mock_ble_h6199")
 async def mock_ble_h6199_fixture(hass) -> AsyncIterator[MockBle]:
     sim = GoveeDeviceSim("H6199")
-    coordinator = GoveeBLECoordinator(hass, TEST_ADDRESS, "H6199")
+    coordinator = GoveeBLECoordinator(hass, TEST_ADDRESS, "H6199", configuration_url=TEST_CONFIGURATION_URL)
     with patch_transport(sim) as client:
         yield MockBle(sim=sim, coordinator=coordinator, client=client)
         await coordinator.disconnect()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,7 +6,9 @@ import pytest
 from bleak import BleakError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ha_govee_led_ble import protocol as proto
 from custom_components.ha_govee_led_ble.const import DOMAIN, MODEL_PROFILES
@@ -20,16 +22,27 @@ from custom_components.ha_govee_led_ble.coordinator import (
 from custom_components.ha_govee_led_ble.scenes import MODEL_SCENES, SCENES
 
 M = "custom_components.ha_govee_led_ble.coordinator"
+_CONFIGURATION_URL = "homeassistant://ha-govee-led-ble/editor/test-entry"
 
 
 @pytest.fixture
 def coord(hass):
-    return GoveeBLECoordinator(hass, "AA:BB:CC:DD:EE:FF", "H617A")
+    return GoveeBLECoordinator(
+        hass,
+        "AA:BB:CC:DD:EE:FF",
+        "H617A",
+        configuration_url=_CONFIGURATION_URL,
+    )
 
 
 @pytest.fixture
 def h6199(hass):
-    return GoveeBLECoordinator(hass, "11:22:33:44:55:66", "H6199")
+    return GoveeBLECoordinator(
+        hass,
+        "11:22:33:44:55:66",
+        "H6199",
+        configuration_url=_CONFIGURATION_URL,
+    )
 
 
 def _c(**kw):
@@ -775,7 +788,12 @@ def test_segment_colors_initial_state(coord, h6199):
 def test_segment_colors_empty_for_unsupported(hass):
     flat = replace(MODEL_PROFILES["H617A"], segment_count=0)
     with patch(f"{M}.get_profile", return_value=flat):
-        c = GoveeBLECoordinator(hass, "AA:BB:CC:DD:EE:00", "H617A")
+        c = GoveeBLECoordinator(
+            hass,
+            "AA:BB:CC:DD:EE:00",
+            "H617A",
+            configuration_url=_CONFIGURATION_URL,
+        )
     assert c.segment_colors == [] and c.profile.segment_count == 0
 
 
@@ -880,7 +898,24 @@ def test_device_info_carries_versions_and_omits_connections(coord):
     info = coord.device_info
     assert info["sw_version"] == "3.02.24" and info["hw_version"] == "3.01.01"
     assert info["identifiers"] == {(DOMAIN, coord.address)}
+    assert info["configuration_url"] == _CONFIGURATION_URL
+    assert coord.address not in info["configuration_url"]
     assert "connections" not in info
+
+
+def test_device_info_replaces_a_stale_configuration_url(hass, coord):
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=coord.address)
+    entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, coord.address)},
+        configuration_url="homeassistant://retired-editor/test-entry",
+    )
+
+    device = registry.async_get_or_create(config_entry_id=entry.entry_id, **coord.device_info)
+
+    assert device.configuration_url == _CONFIGURATION_URL
 
 
 def test_notify_callback_sets_fw_hw_versions(coord):
@@ -1022,7 +1057,12 @@ async def test_first_refresh_reports_update_failed_then_degrades_silently(coord)
 async def test_first_refresh_non_readable_requires_presence(hass):
     flat = replace(MODEL_PROFILES["H617A"], state_readable=False)
     with patch(f"{M}.get_profile", return_value=flat):
-        c = GoveeBLECoordinator(hass, "AA:BB:CC:DD:EE:22", "H617A")
+        c = GoveeBLECoordinator(
+            hass,
+            "AA:BB:CC:DD:EE:22",
+            "H617A",
+            configuration_url=_CONFIGURATION_URL,
+        )
     c._present = False
     with pytest.raises(UpdateFailed):
         await c._async_update_data()

--- a/tests/test_coordinator_modes.py
+++ b/tests/test_coordinator_modes.py
@@ -8,15 +8,27 @@ from custom_components.ha_govee_led_ble.coordinator import GoveeBLECoordinator
 from custom_components.ha_govee_led_ble.coordinator_modes import PreModeSnapshot
 from custom_components.ha_govee_led_ble.light_services import apply_active_video_mode
 
+_CONFIGURATION_URL = "homeassistant://ha-govee-led-ble/editor/test-entry"
+
 
 @pytest.fixture
 def coord(hass):
-    return GoveeBLECoordinator(hass, "AA:BB:CC:DD:EE:FF", "H617A")
+    return GoveeBLECoordinator(
+        hass,
+        "AA:BB:CC:DD:EE:FF",
+        "H617A",
+        configuration_url=_CONFIGURATION_URL,
+    )
 
 
 @pytest.fixture
 def h6199(hass):
-    return GoveeBLECoordinator(hass, "11:22:33:44:55:66", "H6199")
+    return GoveeBLECoordinator(
+        hass,
+        "11:22:33:44:55:66",
+        "H6199",
+        configuration_url=_CONFIGURATION_URL,
+    )
 
 
 def _sent(sc):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,6 +13,13 @@ from custom_components.ha_govee_led_ble import (
     async_unload_entry,
 )
 from custom_components.ha_govee_led_ble.const import CONF_MODEL, DOMAIN, MODEL_PROFILES
+from custom_components.ha_govee_led_ble.editor import (
+    EDITOR_ELEMENT_NAME,
+    EDITOR_MODULE_URL,
+    EDITOR_PANEL_PATH,
+    EDITOR_ROUTE_SEGMENT,
+    editor_url,
+)
 
 
 def _entry(**kw):
@@ -24,6 +31,10 @@ async def test_setup_entry(hass: HomeAssistant):
     entry = _entry()
     with (
         patch("custom_components.ha_govee_led_ble.GoveeBLECoordinator", autospec=True) as cls,
+        patch(
+            "custom_components.ha_govee_led_ble.editor_url",
+            return_value="homeassistant://ha-govee-led-ble/editor/test_entry_id",
+        ) as build_url,
         patch("custom_components.ha_govee_led_ble._async_cleanup_legacy_entities", new_callable=AsyncMock) as cleanup,
         patch.object(hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock) as fwd,
     ):
@@ -34,8 +45,10 @@ async def test_setup_entry(hass: HomeAssistant):
         hass,
         "AA:BB:CC:DD:EE:FF",
         "H617A",
+        configuration_url="homeassistant://ha-govee-led-ble/editor/test_entry_id",
         effect_families=frozenset({"scenes", "music"}),
     )
+    build_url.assert_called_once_with(entry.entry_id)
     assert entry.runtime_data is cls.return_value
     cleanup.assert_awaited_once_with(hass, entry)
     fwd.assert_awaited_once()
@@ -129,7 +142,40 @@ def test_white_balance_replacement_issue_names_old_and_new_entities(hass: HomeAs
     }
 
 
-async def test_async_setup_needs_no_frontend_registration():
+async def test_async_setup_registers_hidden_editor_fallback():
     hass = MagicMock()
     hass.data = {}
-    assert await async_setup(hass, {}) is True
+    hass.http.async_register_static_paths = AsyncMock()
+    with (
+        patch("custom_components.ha_govee_led_ble.editor.frontend.async_panel_exists", return_value=False),
+        patch("custom_components.ha_govee_led_ble.editor.frontend.async_register_built_in_panel") as register,
+    ):
+        assert await async_setup(hass, {}) is True
+
+    hass.http.async_register_static_paths.assert_awaited_once()
+    (static_path,) = hass.http.async_register_static_paths.await_args.args[0]
+    assert static_path.url_path == f"/{DOMAIN}_static"
+    assert static_path.path.endswith("custom_components/ha_govee_led_ble/frontend")
+    assert static_path.cache_headers is False
+    register.assert_called_once_with(
+        hass,
+        component_name="custom",
+        frontend_url_path=EDITOR_PANEL_PATH,
+        config={
+            "configuration_path": f"/config/integrations/integration/{DOMAIN}",
+            "_panel_custom": {
+                "name": EDITOR_ELEMENT_NAME,
+                "module_url": EDITOR_MODULE_URL,
+                "embed_iframe": False,
+                "trust_external": False,
+            },
+        },
+        require_admin=True,
+        show_in_sidebar=False,
+    )
+
+
+def test_editor_device_url_path_matches_registered_panel():
+    url = editor_url("test_entry_id")
+
+    assert url == f"homeassistant://{EDITOR_PANEL_PATH}/{EDITOR_ROUTE_SEGMENT}/test_entry_id"


### PR DESCRIPTION
## Summary

- establish one stable `homeassistant://` device configuration URL
- register a hidden compatibility panel in stable releases
- retain the same route contract for the advanced editor prerelease
- cover registry replacement, privacy and panel registration

Closes #153

## Validation

- `bash scripts/check.sh`
- independent code review found no significant issues