### PR TITLE
fix(release): update latest release after tag move

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           tag_name: latest
           name: latest
-          target_commitish: ${{ steps.semantic_release.outputs.tag }}
           generate_release_notes: false
           prerelease: false
           overwrite_files: true


### PR DESCRIPTION
## Summary

Remove `target_commitish` when updating the existing `latest` release.  The preceding step already moves the `latest` tag to the stable release commit, and GitHub rejects an annotated release tag as the update field.

## Validation

- `bash scripts/check.sh`
- reproduced and removed the `target_commitish` validation failure