### PR TITLE
fix(release): authenticate latest release update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         if: ${{ steps.semantic_release.outputs.released == 'true' && steps.semantic_release.outputs.is_prerelease == 'false' }}
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          token: ${{ secrets.RELEASE_TOKEN }}
           tag_name: latest
           name: latest
           generate_release_notes: false


### PR DESCRIPTION
## Summary

Use `RELEASE_TOKEN` for the `softprops/action-gh-release` update of the mutable `latest` release.  The default workflow token cannot update the release after the tag is force-moved by the release token.

## Validation

- `bash scripts/check.sh`
- reproduced the GitHub `Resource not accessible by integration` failure