### PR TITLE
fix(release): maintain latest as a tag alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,17 +43,3 @@ jobs:
           release_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
           git tag --force latest "$release_commit"
           git push --force origin refs/tags/latest
-
-      - name: Create/Update latest GitHub Release
-        if: ${{ steps.semantic_release.outputs.released == 'true' && steps.semantic_release.outputs.is_prerelease == 'false' }}
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          tag_name: latest
-          name: latest
-          generate_release_notes: false
-          prerelease: false
-          overwrite_files: true
-          body: |
-            Alias release for tooling that resolves by `latest`.
-            Current stable tag: ${{ steps.semantic_release.outputs.tag }}


### PR DESCRIPTION
## Summary

Keep `latest` as a force-moved Git tag alias and remove the redundant GitHub Release update.  Both workflow and PAT tokens are blocked from updating the existing alias release after the tag moves, while the tag operation itself succeeds.

## Validation

- `bash scripts/check.sh`
- tag movement succeeded in the v6.1.1, v6.1.2 and v6.1.3 release runs