### PR TITLE
feat(protocol): parse layered scene parameters

### DIFF
--- a/custom_components/ha_govee_led_ble/generated_protocol_adapter.py
+++ b/custom_components/ha_govee_led_ble/generated_protocol_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import math
 from importlib import import_module
 from typing import Any, cast
 
@@ -44,6 +45,12 @@ DiyType04 = cast(
     Any,
     import_module("custom_components.ha_govee_led_ble.generated_protocol.diy_type04").DiyType04,
 )
+SceneBody = cast(
+    Any,
+    import_module("custom_components.ha_govee_led_ble.generated_protocol.scene_body").SceneBody,
+)
+
+_A3_CHUNK_SIZE = 17
 
 _BLANK_SCREEN_LOW_BRIGHTNESS_SECONDS = 10
 _BLANK_SCREEN_SAME_TONE_SECONDS = 120
@@ -199,6 +206,25 @@ def _a3_header(parent: Any) -> Any:
     header.marker = b"\x01"
     header.linecount = 2
     return header
+
+
+def parse_scene_body_param(raw_param: bytes) -> Any:
+    """Parse a catalogue type-2 parameter through the generated SceneBody root."""
+    if not isinstance(raw_param, bytes):
+        raise TypeError("scene parameter must be bytes")
+    synthetic = SceneBody()
+    header = _a3_header(synthetic)
+    header_length = len(header.marker) + 1
+    header.linecount = max(header.linecount, math.ceil((header_length + 1 + len(raw_param)) / _A3_CHUNK_SIZE))
+    _check_tree(header)
+    header_bytes = _write(header, header_length)
+    envelope = header_bytes + bytes((int(SceneBody.SceneType.scene_v2),)) + raw_param
+    unpadded = SceneBody(KaitaiStream(io.BytesIO(envelope)))
+    unpadded._read()
+    envelope = envelope.ljust(header.linecount * _A3_CHUNK_SIZE, b"\x00")
+    parsed = SceneBody(KaitaiStream(io.BytesIO(envelope)))
+    parsed._read()
+    return parsed
 
 
 def _diy_type04_palette(parent: Any, colours: list[tuple[int, int, int]]) -> Any:

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,7 +1,16 @@
 import base64
+from collections import Counter
+from typing import cast
 
 import pytest
+from kaitaistruct import KaitaiStructError
 
+from custom_components.ha_govee_led_ble.generated_protocol.scene_body import SceneBody
+from custom_components.ha_govee_led_ble.generated_protocol_adapter import (
+    _check_tree,
+    _write,
+    parse_scene_body_param,
+)
 from custom_components.ha_govee_led_ble.protocol import (
     MOVE_ALL_OFFSET,
     MOVE_IN_OFFSET,
@@ -200,3 +209,43 @@ def test_apply_scene_speed_skips_a_page_with_no_matching_record():
     speed = SceneSpeed(0, (ScenePage(page=4, move_in=(99,)),))
 
     assert apply_scene_speed(payload, speed, 0) == payload
+
+
+def test_generated_scene_body_parser_round_trips_type_2_catalogues():
+    scene_counts: Counter[str] = Counter()
+    record_count = 0
+
+    for sku, entries in SCENE_ENTRIES.items():
+        for entry in entries:
+            if entry.scene_type != int(SceneBody.SceneType.scene_v2):
+                continue
+            raw_param = base64.b64decode(entry.param, validate=True)
+            parsed = parse_scene_body_param(raw_param)
+            envelope = cast(bytes, parsed._io.to_byte_array())
+            header_length = len(parsed.header.marker) + 1
+            parameter_start = header_length + 1
+
+            assert parsed.scene_type is SceneBody.SceneType.scene_v2
+            assert len(parsed.records) == int(parsed.num_records)
+            assert envelope[parameter_start : parameter_start + len(raw_param)] == raw_param
+            assert not any(envelope[parameter_start + len(raw_param) :])
+            _check_tree(parsed)
+            assert _write(parsed, len(envelope)) == envelope
+
+            scene_counts[sku] += 1
+            record_count += len(parsed.records)
+
+    assert scene_counts == {"H617A": 72, "H6199": 226}
+    assert record_count == 863
+
+
+@pytest.mark.parametrize("raw_param", [bytearray(b"\x00"), memoryview(b"\x00"), "\x00"])
+def test_generated_scene_body_parser_requires_bytes(raw_param):
+    with pytest.raises(TypeError, match="must be bytes"):
+        parse_scene_body_param(raw_param)
+
+
+@pytest.mark.parametrize("raw_param", [b"", b"\x01", b"\x01\x20"])
+def test_generated_scene_body_parser_rejects_truncated_parameters(raw_param):
+    with pytest.raises(KaitaiStructError):
+        parse_scene_body_param(raw_param)


### PR DESCRIPTION
## Summary
- add a strict bytes-only adapter for catalogue type-2 scene parameters
- reconstruct the generated `SceneBody` transport envelope without hiding truncated records
- verify generated read/write fidelity across all 298 committed type-2 scenes and 863 records

## Scope
This is the parser-only foundation for #165. It deliberately does not add canonical DTOs or semantic decoding; #164 owns the shared model and the remaining #165 integration will rebase onto it.

## Validation
- 40 targeted tests passed
- `bash scripts/check.sh` passed

Refs #165