### PR TITLE
feat(protocol): add canonical layered scene model

### DIFF
--- a/custom_components/ha_govee_led_ble/generated_protocol/govee_shared.py
+++ b/custom_components/ha_govee_led_ble/generated_protocol/govee_shared.py
@@ -290,6 +290,26 @@ class GoveeShared(ReadWriteKaitaiStruct):
 
         def _invalidate_direction_is_backward(self):
             del self._m_direction_is_backward
+        @property
+        def distribution_method(self):
+            if hasattr(self, '_m_distribution_method'):
+                return self._m_distribution_method
+
+            self._m_distribution_method = self.direction_distribution & 127
+            return getattr(self, '_m_distribution_method', None)
+
+        def _invalidate_distribution_method(self):
+            del self._m_distribution_method
+        @property
+        def unknown_flags(self):
+            if hasattr(self, '_m_unknown_flags'):
+                return self._m_unknown_flags
+
+            self._m_unknown_flags = self.layer_flags & 253
+            return getattr(self, '_m_unknown_flags', None)
+
+        def _invalidate_unknown_flags(self):
+            del self._m_unknown_flags
 
     class Movement(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):
@@ -348,6 +368,16 @@ class GoveeShared(ReadWriteKaitaiStruct):
 
         def _invalidate_enter_exit_effect(self):
             del self._m_enter_exit_effect
+        @property
+        def unknown_flags(self):
+            if hasattr(self, '_m_unknown_flags'):
+                return self._m_unknown_flags
+
+            self._m_unknown_flags = self.packed & 232
+            return getattr(self, '_m_unknown_flags', None)
+
+        def _invalidate_unknown_flags(self):
+            del self._m_unknown_flags
 
     class Rgb(ReadWriteKaitaiStruct):
         def __init__(self, _io=None, _parent=None, _root=None):

--- a/custom_components/ha_govee_led_ble/layered_scene.py
+++ b/custom_components/ha_govee_led_ble/layered_scene.py
@@ -1,0 +1,504 @@
+"""Canonical, editor-neutral layered scene values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import IntEnum
+from importlib import import_module
+from typing import Any, cast
+
+type RGB = tuple[int, int, int]
+type JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+
+GoveeShared = cast(
+    Any,
+    import_module("custom_components.ha_govee_led_ble.generated_protocol.govee_shared").GoveeShared,
+)
+
+__all__ = [
+    "AppliedArea",
+    "BrightnessOrder",
+    "BrightnessPattern",
+    "CatalogueRef",
+    "Distribution",
+    "EffectLayer",
+    "LayeredEffect",
+    "LayeredScene",
+    "LayeredSceneValidationError",
+    "Movement",
+    "RGB",
+    "Selection",
+    "SelectionType",
+    "layered_effect_from_value",
+    "layered_effect_to_value",
+    "layered_scene_from_value",
+    "layered_scene_to_value",
+]
+
+_BYTE_COUNT = 0xFF
+_LAYER_GRADIENT_FLAG = 0x02
+_MOVEMENT_KNOWN_FLAGS = 0x17
+
+
+class LayeredSceneValidationError(ValueError):
+    """A layered scene value does not satisfy the canonical contract."""
+
+
+class BrightnessOrder(IntEnum):
+    """Known brightness-order values from the shared Kaitai schema."""
+
+    BRIGHTEST_DARKEST = int(GoveeShared.BrightnessOrder.brightest_darkest)
+    BRIGHTEST_DARKEST_BRIGHTEST = int(GoveeShared.BrightnessOrder.brightest_darkest_brightest)
+    DARKEST_BRIGHTEST = int(GoveeShared.BrightnessOrder.darkest_brightest)
+    DARKEST_BRIGHTEST_DARKEST = int(GoveeShared.BrightnessOrder.darkest_brightest_darkest)
+
+
+class SelectionType(IntEnum):
+    """Known layer-selection values from the shared Kaitai schema."""
+
+    SEGMENT = int(GoveeShared.SelectType.segment)
+    CONTINUOUS = int(GoveeShared.SelectType.select_ic_continuously)
+    RANDOM = int(GoveeShared.SelectType.select_ic_randomly)
+    CUSTOM = int(GoveeShared.SelectType.customize_segment)
+
+
+@dataclass(frozen=True, slots=True)
+class AppliedArea:
+    """The two raw nibbles in a layer's applied-area byte.
+
+    The field names follow the catalogue schema and do not infer physical coverage.
+    """
+
+    start_tenths: int
+    width_tenths: int
+
+    def __post_init__(self) -> None:
+        _validate_nibble(self.start_tenths, "applied-area low nibble")
+        _validate_nibble(self.width_tenths, "applied-area high nibble")
+
+
+@dataclass(frozen=True, slots=True)
+class Selection:
+    type: int
+    param_1: int
+    param_2: int
+
+    def __post_init__(self) -> None:
+        _validate_byte(self.type, "selection type")
+        _validate_byte(self.param_1, "selection parameter 1")
+        _validate_byte(self.param_2, "selection parameter 2")
+
+
+@dataclass(frozen=True, slots=True)
+class BrightnessPattern:
+    scope_high: int
+    scope_low: int
+    order: int
+    change_speed: int
+    brightest_retention: int
+    darkest_retention: int
+
+    def __post_init__(self) -> None:
+        _validate_byte(self.scope_high, "brightness scope high")
+        _validate_byte(self.scope_low, "brightness scope low")
+        _validate_byte(self.order, "brightness order")
+        _validate_byte(self.change_speed, "brightness change speed")
+        _validate_byte(self.brightest_retention, "brightest retention")
+        _validate_byte(self.darkest_retention, "darkest retention")
+
+
+@dataclass(frozen=True, slots=True)
+class Movement:
+    enabled: bool
+    enter_exit: bool
+    direction: int
+    distance: int
+    speed: int
+    unknown_flags: int = 0
+
+    def __post_init__(self) -> None:
+        _validate_bool(self.enabled, "movement enabled")
+        _validate_bool(self.enter_exit, "movement enter-exit")
+        if not _is_int(self.direction) or not 0 <= self.direction <= 3:
+            raise LayeredSceneValidationError("movement direction must be an integer from 0 to 3")
+        _validate_byte(self.distance, "movement distance")
+        _validate_byte(self.speed, "movement speed")
+        _validate_byte(self.unknown_flags, "movement unknown flags")
+        if self.unknown_flags & _MOVEMENT_KNOWN_FLAGS:
+            raise LayeredSceneValidationError("movement unknown flags overlap known flags")
+
+
+@dataclass(frozen=True, slots=True)
+class Distribution:
+    method: int
+    backwards: bool = False
+
+    def __post_init__(self) -> None:
+        if not _is_int(self.method) or not 0 <= self.method <= 0x7F:
+            raise LayeredSceneValidationError("distribution method must be an integer from 0 to 127")
+        _validate_bool(self.backwards, "distribution backwards")
+
+
+@dataclass(frozen=True, slots=True)
+class EffectLayer:
+    area: AppliedArea
+    selection: Selection
+    brightness_gradient: bool
+    brightness_patterns: tuple[BrightnessPattern, ...]
+    distribution: Distribution
+    colour_speed: int
+    colour_retention: int
+    palette: tuple[RGB, ...]
+    selected_movement: Movement
+    overall_movement: Movement
+    priority: int
+    unknown_flags: int = 0
+    excess: bytes = b""
+
+    def __post_init__(self) -> None:
+        _validate_instance(self.area, AppliedArea, "layer area")
+        _validate_instance(self.selection, Selection, "layer selection")
+        _validate_bool(self.brightness_gradient, "layer brightness gradient")
+        _validate_items(self.brightness_patterns, BrightnessPattern, "layer brightness patterns")
+        _validate_instance(self.distribution, Distribution, "layer distribution")
+        _validate_byte(self.colour_speed, "colour speed")
+        _validate_byte(self.colour_retention, "colour retention")
+        _validate_palette(self.palette)
+        _validate_instance(self.selected_movement, Movement, "selected-area movement")
+        _validate_instance(self.overall_movement, Movement, "overall movement")
+        _validate_byte(self.priority, "layer priority")
+        _validate_byte(self.unknown_flags, "layer unknown flags")
+        if self.unknown_flags & _LAYER_GRADIENT_FLAG:
+            raise LayeredSceneValidationError("layer unknown flags overlap the gradient flag")
+        if not isinstance(self.excess, bytes):
+            raise LayeredSceneValidationError("layer excess must be bytes")
+
+
+@dataclass(frozen=True, slots=True)
+class LayeredEffect:
+    layers: tuple[EffectLayer, ...]
+
+    def __post_init__(self) -> None:
+        _validate_items(self.layers, EffectLayer, "effect layers")
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogueRef:
+    sku: str
+    scene_id: int
+    effect_id: int
+    catalogue_schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.sku, str) or not self.sku:
+            raise LayeredSceneValidationError("catalogue SKU must not be empty")
+        _validate_non_negative(self.scene_id, "catalogue scene ID")
+        _validate_non_negative(self.effect_id, "catalogue effect ID")
+        if not _is_int(self.catalogue_schema_version) or self.catalogue_schema_version < 1:
+            raise LayeredSceneValidationError("catalogue schema version must be a positive integer")
+
+
+@dataclass(frozen=True, slots=True)
+class LayeredScene:
+    template: CatalogueRef
+    effect: LayeredEffect
+    speed_index: int | None = None
+    raw_param: bytes = b""
+
+    def __post_init__(self) -> None:
+        _validate_instance(self.template, CatalogueRef, "scene template")
+        _validate_instance(self.effect, LayeredEffect, "scene effect")
+        if self.speed_index is not None:
+            _validate_non_negative(self.speed_index, "scene speed index")
+        if not isinstance(self.raw_param, bytes):
+            raise LayeredSceneValidationError("scene raw parameter must be bytes")
+
+
+def layered_effect_to_value(effect: LayeredEffect) -> dict[str, JsonValue]:
+    """Return an effect as JSON-compatible values."""
+    _validate_instance(effect, LayeredEffect, "layered effect")
+    return {"layers": [_layer_to_value(layer) for layer in effect.layers]}
+
+
+def layered_effect_from_value(raw: Mapping[str, Any]) -> LayeredEffect:
+    """Restore an effect from JSON-compatible values."""
+    return LayeredEffect(
+        tuple(
+            _layer_from_value(_as_mapping(layer, "effect layer"))
+            for layer in _required_sequence(_as_mapping(raw, "layered effect"), "layers")
+        )
+    )
+
+
+def layered_scene_to_value(scene: LayeredScene) -> dict[str, JsonValue]:
+    """Return a layered scene as JSON-compatible values."""
+    _validate_instance(scene, LayeredScene, "layered scene")
+    return {
+        "template": _catalogue_ref_to_value(scene.template),
+        "effect": layered_effect_to_value(scene.effect),
+        "speed_index": scene.speed_index,
+        "raw_param": scene.raw_param.hex(),
+    }
+
+
+def layered_scene_from_value(raw: Mapping[str, Any]) -> LayeredScene:
+    """Restore a layered scene from JSON-compatible values."""
+    value = _as_mapping(raw, "layered scene")
+    return LayeredScene(
+        template=_catalogue_ref_from_value(_required_mapping(value, "template")),
+        effect=layered_effect_from_value(_required_mapping(value, "effect")),
+        speed_index=_optional_int(value, "speed_index"),
+        raw_param=_hex_bytes(value.get("raw_param"), "scene raw parameter"),
+    )
+
+
+def _layer_to_value(layer: EffectLayer) -> dict[str, JsonValue]:
+    return {
+        "area": {
+            "start_tenths": layer.area.start_tenths,
+            "width_tenths": layer.area.width_tenths,
+        },
+        "selection": {
+            "type": layer.selection.type,
+            "param_1": layer.selection.param_1,
+            "param_2": layer.selection.param_2,
+        },
+        "brightness_gradient": layer.brightness_gradient,
+        "brightness_patterns": [
+            {
+                "scope_high": pattern.scope_high,
+                "scope_low": pattern.scope_low,
+                "order": pattern.order,
+                "change_speed": pattern.change_speed,
+                "brightest_retention": pattern.brightest_retention,
+                "darkest_retention": pattern.darkest_retention,
+            }
+            for pattern in layer.brightness_patterns
+        ],
+        "distribution": {
+            "method": layer.distribution.method,
+            "backwards": layer.distribution.backwards,
+        },
+        "colour_speed": layer.colour_speed,
+        "colour_retention": layer.colour_retention,
+        "palette": [list(colour) for colour in layer.palette],
+        "selected_movement": _movement_to_value(layer.selected_movement),
+        "overall_movement": _movement_to_value(layer.overall_movement),
+        "priority": layer.priority,
+        "unknown_flags": layer.unknown_flags,
+        "excess": layer.excess.hex(),
+    }
+
+
+def _layer_from_value(raw: Mapping[str, Any]) -> EffectLayer:
+    area = _required_mapping(raw, "area")
+    selection = _required_mapping(raw, "selection")
+    distribution = _required_mapping(raw, "distribution")
+    return EffectLayer(
+        area=AppliedArea(
+            start_tenths=_required_int(area, "start_tenths"),
+            width_tenths=_required_int(area, "width_tenths"),
+        ),
+        selection=Selection(
+            type=_required_int(selection, "type"),
+            param_1=_required_int(selection, "param_1"),
+            param_2=_required_int(selection, "param_2"),
+        ),
+        brightness_gradient=_required_bool(raw, "brightness_gradient"),
+        brightness_patterns=tuple(
+            _brightness_pattern_from_value(_as_mapping(pattern, "brightness pattern"))
+            for pattern in _required_sequence(raw, "brightness_patterns")
+        ),
+        distribution=Distribution(
+            method=_required_int(distribution, "method"),
+            backwards=_required_bool(distribution, "backwards"),
+        ),
+        colour_speed=_required_int(raw, "colour_speed"),
+        colour_retention=_required_int(raw, "colour_retention"),
+        palette=_palette_from_value(raw.get("palette")),
+        selected_movement=_movement_from_value(_required_mapping(raw, "selected_movement")),
+        overall_movement=_movement_from_value(_required_mapping(raw, "overall_movement")),
+        priority=_required_int(raw, "priority"),
+        unknown_flags=_required_int(raw, "unknown_flags"),
+        excess=_hex_bytes(raw.get("excess"), "layer excess"),
+    )
+
+
+def _brightness_pattern_from_value(raw: Mapping[str, Any]) -> BrightnessPattern:
+    return BrightnessPattern(
+        scope_high=_required_int(raw, "scope_high"),
+        scope_low=_required_int(raw, "scope_low"),
+        order=_required_int(raw, "order"),
+        change_speed=_required_int(raw, "change_speed"),
+        brightest_retention=_required_int(raw, "brightest_retention"),
+        darkest_retention=_required_int(raw, "darkest_retention"),
+    )
+
+
+def _movement_to_value(movement: Movement) -> dict[str, JsonValue]:
+    return {
+        "enabled": movement.enabled,
+        "enter_exit": movement.enter_exit,
+        "direction": movement.direction,
+        "distance": movement.distance,
+        "speed": movement.speed,
+        "unknown_flags": movement.unknown_flags,
+    }
+
+
+def _movement_from_value(raw: Mapping[str, Any]) -> Movement:
+    return Movement(
+        enabled=_required_bool(raw, "enabled"),
+        enter_exit=_required_bool(raw, "enter_exit"),
+        direction=_required_int(raw, "direction"),
+        distance=_required_int(raw, "distance"),
+        speed=_required_int(raw, "speed"),
+        unknown_flags=_required_int(raw, "unknown_flags"),
+    )
+
+
+def _catalogue_ref_to_value(reference: CatalogueRef) -> dict[str, JsonValue]:
+    return {
+        "sku": reference.sku,
+        "scene_id": reference.scene_id,
+        "effect_id": reference.effect_id,
+        "catalogue_schema_version": reference.catalogue_schema_version,
+    }
+
+
+def _catalogue_ref_from_value(raw: Mapping[str, Any]) -> CatalogueRef:
+    return CatalogueRef(
+        sku=_required_str(raw, "sku"),
+        scene_id=_required_int(raw, "scene_id"),
+        effect_id=_required_int(raw, "effect_id"),
+        catalogue_schema_version=_required_int(raw, "catalogue_schema_version"),
+    )
+
+
+def _validate_items[ItemT](value: tuple[ItemT, ...], item_type: type[ItemT], name: str) -> None:
+    if not isinstance(value, tuple):
+        raise LayeredSceneValidationError(f"{name} must be a tuple")
+    if len(value) > _BYTE_COUNT:
+        raise LayeredSceneValidationError(f"{name} must contain at most {_BYTE_COUNT} items")
+    for item in value:
+        _validate_instance(item, item_type, name)
+
+
+def _validate_palette(palette: tuple[RGB, ...]) -> None:
+    if not isinstance(palette, tuple):
+        raise LayeredSceneValidationError("layer palette must be a tuple")
+    if len(palette) > _BYTE_COUNT:
+        raise LayeredSceneValidationError(f"layer palette must contain at most {_BYTE_COUNT} colours")
+    for colour in palette:
+        _validate_rgb(colour, "layer palette colour")
+
+
+def _validate_rgb(value: RGB, name: str) -> None:
+    if not isinstance(value, tuple) or len(value) != 3:
+        raise LayeredSceneValidationError(f"{name} must be an RGB tuple")
+    for channel in value:
+        _validate_byte(channel, f"{name} channel")
+
+
+def _validate_instance[ItemT](value: object, item_type: type[ItemT], name: str) -> None:
+    if not isinstance(value, item_type):
+        raise LayeredSceneValidationError(f"{name} must be {item_type.__name__}")
+
+
+def _validate_non_negative(value: int, name: str) -> None:
+    if not _is_int(value) or value < 0:
+        raise LayeredSceneValidationError(f"{name} must be a non-negative integer")
+
+
+def _validate_nibble(value: int, name: str) -> None:
+    if not _is_int(value) or not 0 <= value <= 0x0F:
+        raise LayeredSceneValidationError(f"{name} must be an integer from 0 to 15")
+
+
+def _validate_byte(value: int, name: str) -> None:
+    if not _is_int(value) or not 0 <= value <= 0xFF:
+        raise LayeredSceneValidationError(f"{name} must be an integer from 0 to 255")
+
+
+def _validate_bool(value: bool, name: str) -> None:
+    if not isinstance(value, bool):
+        raise LayeredSceneValidationError(f"{name} must be a boolean")
+
+
+def _is_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _as_mapping(value: object, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise LayeredSceneValidationError(f"{name} must be a mapping")
+    return cast(Mapping[str, Any], value)
+
+
+def _required_mapping(raw: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    if key not in raw:
+        raise LayeredSceneValidationError(f"missing required field {key!r}")
+    return _as_mapping(raw[key], key)
+
+
+def _required_sequence(raw: Mapping[str, Any], key: str) -> Sequence[Any]:
+    value = raw.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        raise LayeredSceneValidationError(f"{key} must be a list")
+    return value
+
+
+def _required_int(raw: Mapping[str, Any], key: str) -> int:
+    value = raw.get(key)
+    if not _is_int(value):
+        raise LayeredSceneValidationError(f"{key} must be an integer")
+    return cast(int, value)
+
+
+def _optional_int(raw: Mapping[str, Any], key: str) -> int | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not _is_int(value):
+        raise LayeredSceneValidationError(f"{key} must be an integer or null")
+    return cast(int, value)
+
+
+def _required_bool(raw: Mapping[str, Any], key: str) -> bool:
+    value = raw.get(key)
+    if not isinstance(value, bool):
+        raise LayeredSceneValidationError(f"{key} must be a boolean")
+    return value
+
+
+def _required_str(raw: Mapping[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str):
+        raise LayeredSceneValidationError(f"{key} must be a string")
+    return value
+
+
+def _palette_from_value(value: object) -> tuple[RGB, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes):
+        raise LayeredSceneValidationError("palette must be a list")
+    return tuple(_rgb_from_value(colour, "palette colour") for colour in value)
+
+
+def _rgb_from_value(value: object, name: str) -> RGB:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes) or len(value) != 3:
+        raise LayeredSceneValidationError(f"{name} must contain three integer channels")
+    if any(not _is_int(channel) for channel in value):
+        raise LayeredSceneValidationError(f"{name} must contain three integer channels")
+    rgb = cast(RGB, tuple(value))
+    _validate_rgb(rgb, name)
+    return rgb
+
+
+def _hex_bytes(value: object, name: str) -> bytes:
+    if not isinstance(value, str):
+        raise LayeredSceneValidationError(f"{name} must be a hexadecimal string")
+    try:
+        return bytes.fromhex(value)
+    except ValueError as exc:
+        raise LayeredSceneValidationError(f"{name} must be a hexadecimal string") from exc

--- a/custom_components/ha_govee_led_ble/layered_scene.py
+++ b/custom_components/ha_govee_led_ble/layered_scene.py
@@ -1,4 +1,19 @@
-"""Canonical, editor-neutral layered scene values."""
+"""Canonical, editor-neutral layered scene values.
+
+``effect_domain.py`` must import and re-export ``AppliedArea``, ``BrightnessOrder``,
+``BrightnessPattern``, ``CatalogueRef``, ``Distribution``, ``EffectLayer``,
+``LayeredEffect``, ``LayeredScene``, ``Movement``, ``Selection`` and
+``SelectionType`` rather than defining parallel layered types.  It must alias
+``LayeredSceneValidationError`` as its shared ``EffectValidationError`` and delegate
+the ``advanced`` and ``scene_layered`` JSON bodies to the value converters here.
+
+``Selection.type`` and ``BrightnessPattern.order`` remain raw integers so unknown
+wire values survive persistence.  Their enums provide names for known values only.
+Authoring limits belong in UX editor and capability validation, not this module.
+Decoders source split flag values from generated Kaitai properties.  The
+``raw_param`` field records source provenance; these converters do not encode edited
+DTOs back to wire bytes.
+"""
 
 from __future__ import annotations
 
@@ -37,8 +52,6 @@ __all__ = [
 ]
 
 _BYTE_COUNT = 0xFF
-_LAYER_GRADIENT_FLAG = 0x02
-_MOVEMENT_KNOWN_FLAGS = 0x17
 
 
 class LayeredSceneValidationError(ValueError):
@@ -125,8 +138,6 @@ class Movement:
         _validate_byte(self.distance, "movement distance")
         _validate_byte(self.speed, "movement speed")
         _validate_byte(self.unknown_flags, "movement unknown flags")
-        if self.unknown_flags & _MOVEMENT_KNOWN_FLAGS:
-            raise LayeredSceneValidationError("movement unknown flags overlap known flags")
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,8 +180,6 @@ class EffectLayer:
         _validate_instance(self.overall_movement, Movement, "overall movement")
         _validate_byte(self.priority, "layer priority")
         _validate_byte(self.unknown_flags, "layer unknown flags")
-        if self.unknown_flags & _LAYER_GRADIENT_FLAG:
-            raise LayeredSceneValidationError("layer unknown flags overlap the gradient flag")
         if not isinstance(self.excess, bytes):
             raise LayeredSceneValidationError("layer excess must be bytes")
 
@@ -260,7 +269,7 @@ def _layer_to_value(layer: EffectLayer) -> dict[str, JsonValue]:
             "width_tenths": layer.area.width_tenths,
         },
         "selection": {
-            "type": layer.selection.type,
+            "type": int(layer.selection.type),
             "param_1": layer.selection.param_1,
             "param_2": layer.selection.param_2,
         },
@@ -269,7 +278,7 @@ def _layer_to_value(layer: EffectLayer) -> dict[str, JsonValue]:
             {
                 "scope_high": pattern.scope_high,
                 "scope_low": pattern.scope_low,
-                "order": pattern.order,
+                "order": int(pattern.order),
                 "change_speed": pattern.change_speed,
                 "brightest_retention": pattern.brightest_retention,
                 "darkest_retention": pattern.darkest_retention,

--- a/tests/test_layered_scene.py
+++ b/tests/test_layered_scene.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import base64
 import json
+from collections import Counter
 from dataclasses import replace
+from typing import Any, cast
 
 import pytest
 
+from custom_components.ha_govee_led_ble.generated_protocol.scene_body import SceneBody
+from custom_components.ha_govee_led_ble.generated_protocol_adapter import (
+    _check_tree,
+    _write,
+    parse_scene_body_param,
+)
 from custom_components.ha_govee_led_ble.layered_scene import (
     AppliedArea,
     BrightnessOrder,
@@ -25,6 +34,7 @@ from custom_components.ha_govee_led_ble.layered_scene import (
     layered_scene_from_value,
     layered_scene_to_value,
 )
+from custom_components.ha_govee_led_ble.scenes import SCENE_ENTRIES
 
 
 def _layer() -> EffectLayer:
@@ -52,6 +62,135 @@ def _layer() -> EffectLayer:
         unknown_flags=0xFD,
         excess=b"\xaa\xbb",
     )
+
+
+def _movement_from_parsed(movement: Any) -> Movement:
+    return Movement(
+        enabled=bool(movement.enabled),
+        enter_exit=bool(movement.enter_exit_effect),
+        direction=int(movement.direction),
+        distance=int(movement.interval),
+        speed=int(movement.speed),
+        unknown_flags=int(movement.unknown_flags),
+    )
+
+
+def _layer_from_parsed(layer: Any) -> EffectLayer:
+    return EffectLayer(
+        area=AppliedArea(
+            start_tenths=int(layer.applied_area_start_tenths),
+            width_tenths=int(layer.applied_area_width_tenths),
+        ),
+        selection=Selection(
+            type=int(layer.select_type),
+            param_1=int(layer.select_param_1),
+            param_2=int(layer.select_param_2),
+        ),
+        brightness_gradient=bool(layer.brightness_is_gradient),
+        brightness_patterns=tuple(
+            BrightnessPattern(
+                scope_high=int(block.scope_high),
+                scope_low=int(block.scope_low),
+                order=int(block.order),
+                change_speed=int(block.change_speed),
+                brightest_retention=int(block.retention_brightest),
+                darkest_retention=int(block.retention_darkest),
+            )
+            for block in layer.brightness_blocks
+        ),
+        distribution=Distribution(
+            method=int(layer.distribution_method),
+            backwards=bool(layer.direction_is_backward),
+        ),
+        colour_speed=int(layer.colour_speed),
+        colour_retention=int(layer.colour_retention),
+        palette=tuple((int(colour.r), int(colour.g), int(colour.b)) for colour in layer.palette),
+        selected_movement=_movement_from_parsed(layer.selected_area_movement),
+        overall_movement=_movement_from_parsed(layer.overall_movement),
+        priority=int(layer.priority),
+        unknown_flags=int(layer.unknown_flags),
+        excess=bytes(layer.excess),
+    )
+
+
+def test_effect_domain_compatibility_shape_uses_raw_integer_values() -> None:
+    pattern = replace(_layer().brightness_patterns[0], order=0xFD)
+    layer = replace(
+        _layer(),
+        selection=Selection(0xFE, 1, 2),
+        brightness_patterns=(pattern,),
+        palette=((1, 2, 3),),
+    )
+    effect = LayeredEffect((layer,))
+    expected_effect = {
+        "layers": [
+            {
+                "area": {"start_tenths": 0, "width_tenths": 0},
+                "selection": {"type": 0xFE, "param_1": 1, "param_2": 2},
+                "brightness_gradient": True,
+                "brightness_patterns": [
+                    {
+                        "scope_high": 0,
+                        "scope_low": 255,
+                        "order": 0xFD,
+                        "change_speed": 255,
+                        "brightest_retention": 0,
+                        "darkest_retention": 255,
+                    }
+                ],
+                "distribution": {"method": 127, "backwards": True},
+                "colour_speed": 255,
+                "colour_retention": 0,
+                "palette": [[1, 2, 3]],
+                "selected_movement": {
+                    "enabled": True,
+                    "enter_exit": False,
+                    "direction": 3,
+                    "distance": 0,
+                    "speed": 255,
+                    "unknown_flags": 0xA8,
+                },
+                "overall_movement": {
+                    "enabled": False,
+                    "enter_exit": True,
+                    "direction": 0,
+                    "distance": 255,
+                    "speed": 0,
+                    "unknown_flags": 0,
+                },
+                "priority": 255,
+                "unknown_flags": 0xFD,
+                "excess": "aabb",
+            }
+        ]
+    }
+    effect_value = layered_effect_to_value(effect)
+    scene_value = layered_scene_to_value(
+        LayeredScene(
+            template=CatalogueRef("H617A", 1033, 1095),
+            effect=effect,
+            speed_index=2,
+            raw_param=b"\x00\xff",
+        )
+    )
+
+    assert effect_value == expected_effect
+    layer_value = cast(dict[str, Any], cast(list[Any], effect_value["layers"])[0])
+    selection_value = cast(dict[str, Any], layer_value["selection"])
+    pattern_value = cast(dict[str, Any], cast(list[Any], layer_value["brightness_patterns"])[0])
+    assert type(selection_value["type"]) is int
+    assert type(pattern_value["order"]) is int
+    assert scene_value == {
+        "template": {
+            "sku": "H617A",
+            "scene_id": 1033,
+            "effect_id": 1095,
+            "catalogue_schema_version": 1,
+        },
+        "effect": expected_effect,
+        "speed_index": 2,
+        "raw_param": "00ff",
+    }
 
 
 def test_committed_catalogue_extremes_round_trip_through_json() -> None:
@@ -119,6 +258,53 @@ def test_unknown_enums_flags_and_excess_round_trip_without_normalisation() -> No
     assert restored_layer.excess == b"\xaa\xbb"
 
 
+def test_generated_unknown_flag_properties_feed_the_canonical_split() -> None:
+    entry = next(entry for entry in SCENE_ENTRIES["H617A"] if entry.scene_type == int(SceneBody.SceneType.scene_v2))
+    parsed = parse_scene_body_param(base64.b64decode(entry.param, validate=True))
+    layer = parsed.records[0].body
+    layer.layer_flags |= 0x80
+    layer.selected_area_movement.packed |= 0x20
+
+    canonical = _layer_from_parsed(layer)
+
+    assert canonical.unknown_flags == 0x80
+    assert canonical.selected_movement.unknown_flags == 0x20
+
+
+def test_all_committed_layered_scenes_round_trip_canonical_values() -> None:
+    scene_counts: Counter[str] = Counter()
+    record_count = 0
+
+    for sku, entries in SCENE_ENTRIES.items():
+        for entry in entries:
+            if entry.scene_type != int(SceneBody.SceneType.scene_v2):
+                continue
+            raw_param = base64.b64decode(entry.param, validate=True)
+            parsed = parse_scene_body_param(raw_param)
+            envelope = cast(bytes, parsed._io.to_byte_array())
+            canonical = LayeredScene(
+                template=CatalogueRef(sku, entry.scene_id, entry.effect_id),
+                effect=LayeredEffect(tuple(_layer_from_parsed(record.body) for record in parsed.records)),
+                speed_index=entry.speed.default_index if entry.speed is not None else None,
+                raw_param=raw_param,
+            )
+            value = layered_scene_to_value(canonical)
+            restored = layered_scene_from_value(json.loads(json.dumps(value)))
+
+            assert restored == canonical
+            assert layered_scene_to_value(restored) == value
+            assert restored.raw_param == raw_param
+            assert len(restored.effect.layers) == int(parsed.num_records)
+            _check_tree(parsed)
+            assert _write(parsed, len(envelope)) == envelope
+
+            scene_counts[sku] += 1
+            record_count += len(restored.effect.layers)
+
+    assert scene_counts == {"H617A": 72, "H6199": 226}
+    assert record_count == 863
+
+
 def test_wire_sized_collections_do_not_apply_authoring_minimums() -> None:
     empty_layer = replace(_layer(), brightness_patterns=(), palette=())
 
@@ -149,10 +335,8 @@ def test_wire_sized_collections_accept_byte_count_maximums() -> None:
         lambda: AppliedArea(0, -1),
         lambda: Selection(True, 0, 0),
         lambda: BrightnessPattern(0, 0, 256, 0, 0, 0),
-        lambda: Movement(True, False, 0, 0, 0, unknown_flags=0x10),
         lambda: Distribution(128),
         lambda: replace(_layer(), priority=256),
-        lambda: replace(_layer(), unknown_flags=0x02),
         lambda: replace(_layer(), brightness_patterns=_layer().brightness_patterns * 256),
         lambda: replace(_layer(), palette=((0, 0, 0),) * 256),
         lambda: LayeredEffect((_layer(),) * 256),

--- a/tests/test_layered_scene.py
+++ b/tests/test_layered_scene.py
@@ -1,0 +1,163 @@
+"""Canonical layered-scene value tests."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from custom_components.ha_govee_led_ble.layered_scene import (
+    AppliedArea,
+    BrightnessOrder,
+    BrightnessPattern,
+    CatalogueRef,
+    Distribution,
+    EffectLayer,
+    LayeredEffect,
+    LayeredScene,
+    LayeredSceneValidationError,
+    Movement,
+    Selection,
+    SelectionType,
+    layered_effect_from_value,
+    layered_effect_to_value,
+    layered_scene_from_value,
+    layered_scene_to_value,
+)
+
+
+def _layer() -> EffectLayer:
+    return EffectLayer(
+        area=AppliedArea(0, 0),
+        selection=Selection(SelectionType.CUSTOM, 0, 255),
+        brightness_gradient=True,
+        brightness_patterns=(
+            BrightnessPattern(
+                scope_high=0,
+                scope_low=255,
+                order=BrightnessOrder.BRIGHTEST_DARKEST,
+                change_speed=255,
+                brightest_retention=0,
+                darkest_retention=255,
+            ),
+        ),
+        distribution=Distribution(127, backwards=True),
+        colour_speed=255,
+        colour_retention=0,
+        palette=tuple((value, value + 1, value + 2) for value in range(11)),
+        selected_movement=Movement(True, False, 3, 0, 255, unknown_flags=0xA8),
+        overall_movement=Movement(False, True, 0, 255, 0),
+        priority=255,
+        unknown_flags=0xFD,
+        excess=b"\xaa\xbb",
+    )
+
+
+def test_committed_catalogue_extremes_round_trip_through_json() -> None:
+    layer = _layer()
+    effect = LayeredEffect(
+        tuple(
+            replace(
+                layer,
+                area=AppliedArea(9, 10) if index == 1 else layer.area,
+                priority=priority,
+            )
+            for index, priority in enumerate((255, 5, 4, 3, 2, 0))
+        )
+    )
+
+    document = json.loads(json.dumps(layered_effect_to_value(effect)))
+    restored = layered_effect_from_value(document)
+
+    assert restored == effect
+    assert restored.layers[0].area == AppliedArea(0, 0)
+    assert restored.layers[1].area == AppliedArea(9, 10)
+    assert len(restored.layers[0].palette) == 11
+    assert tuple(layer.priority for layer in restored.layers) == (255, 5, 4, 3, 2, 0)
+    assert restored.layers[0].brightness_patterns[0].scope_low == 255
+
+
+def test_applied_area_preserves_the_full_raw_nibble_range() -> None:
+    effect = LayeredEffect((replace(_layer(), area=AppliedArea(15, 15)),))
+
+    assert layered_effect_from_value(layered_effect_to_value(effect)) == effect
+
+
+def test_scene_round_trip_preserves_raw_parameter_provenance() -> None:
+    scene = LayeredScene(
+        template=CatalogueRef("H617A", scene_id=1033, effect_id=1095),
+        effect=LayeredEffect((_layer(),)),
+        speed_index=2,
+        raw_param=b"\x00\xff\x10\x80",
+    )
+
+    document = json.loads(json.dumps(layered_scene_to_value(scene)))
+
+    assert document["raw_param"] == "00ff1080"
+    assert layered_scene_from_value(document) == scene
+
+
+def test_unknown_enums_flags_and_excess_round_trip_without_normalisation() -> None:
+    layer = replace(
+        _layer(),
+        selection=Selection(0xFE, 1, 2),
+        brightness_patterns=(
+            replace(
+                _layer().brightness_patterns[0],
+                order=0xFD,
+            ),
+        ),
+    )
+    restored = layered_effect_from_value(layered_effect_to_value(LayeredEffect((layer,))))
+    restored_layer = restored.layers[0]
+
+    assert restored_layer.selection.type == 0xFE
+    assert restored_layer.brightness_patterns[0].order == 0xFD
+    assert restored_layer.unknown_flags == 0xFD
+    assert restored_layer.selected_movement.unknown_flags == 0xA8
+    assert restored_layer.excess == b"\xaa\xbb"
+
+
+def test_wire_sized_collections_do_not_apply_authoring_minimums() -> None:
+    empty_layer = replace(_layer(), brightness_patterns=(), palette=())
+
+    assert LayeredEffect(()) == layered_effect_from_value({"layers": []})
+    assert layered_effect_from_value(layered_effect_to_value(LayeredEffect((empty_layer,)))) == LayeredEffect(
+        (empty_layer,)
+    )
+
+
+def test_wire_sized_collections_accept_byte_count_maximums() -> None:
+    layer = _layer()
+    maximal_layer = replace(
+        layer,
+        brightness_patterns=(layer.brightness_patterns[0],) * 255,
+        palette=((0, 0, 0),) * 255,
+    )
+    effect = LayeredEffect((maximal_layer,) * 255)
+
+    assert len(effect.layers) == 255
+    assert len(effect.layers[0].brightness_patterns) == 255
+    assert len(effect.layers[0].palette) == 255
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: AppliedArea(16, 0),
+        lambda: AppliedArea(0, -1),
+        lambda: Selection(True, 0, 0),
+        lambda: BrightnessPattern(0, 0, 256, 0, 0, 0),
+        lambda: Movement(True, False, 0, 0, 0, unknown_flags=0x10),
+        lambda: Distribution(128),
+        lambda: replace(_layer(), priority=256),
+        lambda: replace(_layer(), unknown_flags=0x02),
+        lambda: replace(_layer(), brightness_patterns=_layer().brightness_patterns * 256),
+        lambda: replace(_layer(), palette=((0, 0, 0),) * 256),
+        lambda: LayeredEffect((_layer(),) * 256),
+    ],
+)
+def test_wire_model_rejects_unrepresentable_values(factory) -> None:
+    with pytest.raises(LayeredSceneValidationError):
+        factory()

--- a/tools/ble/kaitai/govee_shared.ksy
+++ b/tools/ble/kaitai/govee_shared.ksy
@@ -61,6 +61,8 @@ types:
         value: '(packed & 0x04) != 0'
       direction:
         value: 'packed & 0x03'
+      unknown_flags:
+        value: 'packed & 0xe8'
   effect_layer:
     seq:
       - id: applied_area
@@ -107,8 +109,12 @@ types:
         value: 'applied_area & 0x0f'
       direction_is_backward:
         value: '(direction_distribution & 0x80) != 0'
+      distribution_method:
+        value: 'direction_distribution & 0x7f'
       brightness_is_gradient:
         value: '(layer_flags & 0x02) != 0'
+      unknown_flags:
+        value: 'layer_flags & 0xfd'
   scene_type1_content:
     seq:
       - id: config


### PR DESCRIPTION
## Summary
- add a protocol/editor-neutral canonical layered-scene model with raw-preserving validation and stable conversion
- expose semantic flag residuals through Kaitai-generated properties instead of handwritten wire masks
- define and test the exact import/re-export contract that the prerelease `ux` stack will use to retire its duplicate model
- verify all 298 committed type-2 scenes and 863 records parse and round-trip through canonical JSON without changing raw provenance

## Scope
This separates captured wire fidelity from editor authoring limits. It adds no encoder, Apply path, WebSocket API, frontend or H6199 write support.

## Validation
- 19 targeted tests passed
- `bash scripts/check.sh` passed
- independent architecture review passed after resolving the convergence and corpus-coverage findings

Closes #164