### PR TITLE
fix(ci): isolate prerelease dependency caches

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -86,16 +86,16 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version-file: .node-version
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.14"
+          enable-cache: false
 
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4
         with:
           install_args: github:kaitai-io/kaitai_struct_compiler
+          cache: false
 
       - name: Build deterministic package
         run: |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities through [GitHub private vulnerability reporting](https://github.com/teh-hippo/ha-govee-led-ble/security/advisories/new).  Do not
+include vulnerability details in a public issue.
+
+Include the affected component, workflow, dependency, or immutable release reference when known, along with the impact and reproducible steps.  Remove credentials,
+tokens, personal information, and unrelated private data from the report.


### PR DESCRIPTION
## Summary

- disable writable dependency caches in the manually dispatched prerelease package job
- retain immutable SHA and trusted `ux` ancestry checks
- add the shared private vulnerability reporting policy from common-repo-configs v3.2.4

## Validation

- `bash scripts/check.sh`
- `actionlint -color=false .github/workflows/prerelease.yml`
- `git diff --check`