### PR TITLE
fix(ci): validate prerelease revision before checkout

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -44,7 +44,6 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.target_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -52,12 +51,13 @@ jobs:
         env:
           TARGET_SHA: ${{ inputs.target_sha }}
         run: |
-          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
           git fetch --no-tags origin ux
           git merge-base --is-ancestor "$TARGET_SHA" origin/ux || {
             echo "target_sha is not reachable from the remote ux branch" >&2
             exit 1
           }
+          git checkout --detach "$TARGET_SHA"
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
 
       - name: Verify source version
         env:


### PR DESCRIPTION
## Summary

- check that the selected immutable SHA is reachable from the trusted `ux` branch before checking it out
- keep all dependency caches disabled while executing the selected revision
- retain read-only package permissions and the separate write-scoped publish job

This removes the untrusted-reference checkout data flow reported by CodeQL alert 5 without weakening the immutable SHA or trusted ancestry controls.

## Validation

- `bash scripts/check.sh`
- `actionlint -color=false .github/workflows/prerelease.yml`
- `git diff --check`