### PR TITLE
fix: synchronise integration release version

### DIFF
--- a/custom_components/ha_govee_led_ble/manifest.json
+++ b/custom_components/ha_govee_led_ble/manifest.json
@@ -59,5 +59,5 @@
     "requirements": [
         "kaitaistruct==0.11"
     ],
-    "version": "7.2.0rc5"
+    "version": "7.2.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,7 @@ override-dependencies = [
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-version_variables = ["custom_components/ha_govee_led_ble/manifest.json:version"]
-build_command = "pip install uv && uv lock"
+build_command = "python scripts/sync_manifest_version.py && pip install uv && uv lock"
 commit_message = "chore(release): {version}"
 tag_format = "v{version}"
 assets = ["uv.lock"]

--- a/scripts/sync_manifest_version.py
+++ b/scripts/sync_manifest_version.py
@@ -1,0 +1,20 @@
+"""Synchronise the integration manifest with the project version."""
+
+import json
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+PROJECT_PATH = ROOT / "pyproject.toml"
+MANIFEST_PATH = ROOT / "custom_components/ha_govee_led_ble/manifest.json"
+
+
+def main() -> None:
+    version = tomllib.loads(PROJECT_PATH.read_text(encoding="utf-8"))["project"]["version"]
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    manifest["version"] = version
+    MANIFEST_PATH.write_text(f"{json.dumps(manifest, indent=4)}\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import stat
 import subprocess
+import tomllib
 from hashlib import sha256
 from pathlib import Path
 from zipfile import ZipFile
@@ -42,6 +44,13 @@ _CONTRACT_FILES = (
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def test_project_and_manifest_versions_match() -> None:
+    project = tomllib.loads((_REPO / "pyproject.toml").read_text(encoding="utf-8"))
+    manifest = json.loads((_REPO / "custom_components/ha_govee_led_ble/manifest.json").read_text(encoding="utf-8"))
+
+    assert manifest["version"] == project["project"]["version"]
 
 
 def _executable(path: Path, content: str) -> None:


### PR DESCRIPTION
## Summary

- synchronise `manifest.json` from the semantic-release project version before the release commit and tag
- remove the ineffective JSON `version_variables` entry
- add a regression test requiring project and integration versions to match

The v7.2.0 release asset retained the RC5 manifest version.  This patch will publish v7.2.1 with a correct stable manifest and prevent recurrence.
