### PR TITLE
feat: add partial H6076 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Local BLE control and effect authoring for supported Govee lights from Home Assi
 | **H617A** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 83 scenes, 11 music modes and Effect Studio | Repository Kaitai schemas and physical qualification |
 | **H617E** | Supported | H617A-compatible controls, scenes, effects and music modes | H617A-compatible profile and physical owner feedback |
 | **H6199** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 240 scenes, video and music modes, advanced controls and Effect Studio | Repository Kaitai schemas and physical qualification |
-| **H6076** | Experimental | Candidate power, brightness, RGB and 2700–6500 K colour temperature; no colour-mode readback, segments, scenes, music or Effect Studio | [#247](https://github.com/teh-hippo/ha-govee-led-ble/issues/247) |
+| **H6076** | Partial | Confirmed power, brightness, RGB and 2700–6500 K colour temperature; colour-mode readback, segments, scenes, music and Effect Studio remain unavailable | [#247](https://github.com/teh-hippo/ha-govee-led-ble/issues/247) |
 
 **Experimental** is a model-specific prerelease awaiting owner confirmation.  **Partial** has confirmed controls plus known disabled gaps.  **Compatible** has no known issue in its exposed feature set but incomplete documentation.  **Supported** is fully documented, with every known feature implemented or explicitly excluded.  See [CONTRIBUTING.md](CONTRIBUTING.md) for the request, prerelease and promotion process.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Local BLE control and effect authoring for supported Govee lights from Home Assi
 
 ## Effect Studio
 
-Govee Effect Studio is added to the Home Assistant sidebar when the integration loads.  It provides local, model-aware effect editing without a Govee cloud account.
+Govee Effect Studio is added to the Home Assistant sidebar when at least one enabled configured light supports it.  Users can hide or
+reorder the panel through Home Assistant's sidebar settings.  It provides local, model-aware effect editing without a Govee cloud account.
 
 | Model | Studio surfaces |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Local BLE control and effect authoring for supported Govee lights from Home Assi
 | **H617A** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 83 scenes, 11 music modes and Effect Studio | Repository Kaitai schemas and physical qualification |
 | **H617E** | Supported | H617A-compatible controls, scenes, effects and music modes | H617A-compatible profile and physical owner feedback |
 | **H6199** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 240 scenes, video and music modes, advanced controls and Effect Studio | Repository Kaitai schemas and physical qualification |
+| **H6076** | Experimental | Candidate power, brightness, RGB and 2700–6500 K colour temperature; no colour-mode readback, segments, scenes, music or Effect Studio | [#247](https://github.com/teh-hippo/ha-govee-led-ble/issues/247) |
 
 **Experimental** is a model-specific prerelease awaiting owner confirmation.  **Partial** has confirmed controls plus known disabled gaps.  **Compatible** has no known issue in its exposed feature set but incomplete documentation.  **Supported** is fully documented, with every known feature implemented or explicitly excluded.  See [CONTRIBUTING.md](CONTRIBUTING.md) for the request, prerelease and promotion process.
 
@@ -48,6 +49,7 @@ Effect definitions are model-specific.  A strip cannot return the body uploaded 
 
 ## Upgrade notes
 
+- An H6076 previously configured as H617A must be explicitly changed to H6076 through the integration's **Reconfigure** action.  The config entry and entity identity are preserved.
 - Version 7 adds Effect Studio while retaining the standard Home Assistant light effect selector introduced in version 6.
 - The standalone H617A scene-speed entity remains removed.  Edit scene speed in Effect Studio or select the native scene through the light effect selector.
 - Renaming a saved effect immediately changes its selector name.  Name-based automations must use the new name; the stable effect ID does not change.

--- a/custom_components/ha_govee_led_ble/__init__.py
+++ b/custom_components/ha_govee_led_ble/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import Any
 
-from homeassistant.components import bluetooth
+from homeassistant.components import bluetooth, frontend
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
@@ -30,9 +30,10 @@ from .const import (
     model_from_ble_name,
     prefix_effect_names_from_options,
     resolve_model,
+    supported_effect_categories,
 )
 from .coordinator import GoveeBLECoordinator, clear_availability_log_state
-from .editor import async_register_editor_panel, editor_url
+from .editor import EDITOR_PANEL_PATH, async_register_editor_panel, editor_url
 from .effect_setup import async_setup_effects, get_effect_backend
 from .light_services import async_register_light_services
 
@@ -90,8 +91,46 @@ def _unsupported_model_issue_id(entry: GoveeBLEConfigEntry) -> str:
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async_register_light_services(hass)
     effects = await async_setup_effects(hass)
-    await async_register_editor_panel(hass, advanced_available=effects is not None)
+    await async_register_editor_panel(
+        hass,
+        advanced_available=effects is not None,
+        show_in_sidebar=_effect_studio_sidebar_visible(hass),
+    )
     return True
+
+
+def _entry_supports_effect_studio(entry: ConfigEntry[Any]) -> bool:
+    raw_model = entry.data.get(CONF_MODEL)
+    model = resolve_model(raw_model) if isinstance(raw_model, str) else None
+    return model is not None and bool(supported_effect_categories(model))
+
+
+def _effect_studio_sidebar_visible(
+    hass: HomeAssistant,
+    *,
+    excluding_entry_id: str | None = None,
+) -> bool:
+    return any(
+        entry.entry_id != excluding_entry_id and entry.disabled_by is None and _entry_supports_effect_studio(entry)
+        for entry in hass.config_entries.async_entries(DOMAIN)
+    )
+
+
+async def _async_update_editor_panel(
+    hass: HomeAssistant,
+    *,
+    excluding_entry_id: str | None = None,
+) -> None:
+    if hass.is_stopping or not frontend.async_panel_exists(hass, EDITOR_PANEL_PATH):
+        return
+    await async_register_editor_panel(
+        hass,
+        advanced_available=get_effect_backend(hass) is not None,
+        show_in_sidebar=_effect_studio_sidebar_visible(
+            hass,
+            excluding_entry_id=excluding_entry_id,
+        ),
+    )
 
 
 async def _async_cleanup_legacy_entities(hass: HomeAssistant, entry: GoveeBLEConfigEntry) -> None:
@@ -172,7 +211,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoveeBLEConfigEntry) -> 
         hass,
         entry.unique_id,
         model,
-        configuration_url=editor_url(entry.entry_id),
+        configuration_url=editor_url(entry.entry_id) if supported_effect_categories(model) else None,
         effect_families=effect_families_from_options(model, entry.options),
         effect_categories=effect_categories_from_options(model, entry.options),
         prefix_effect_names=prefix_effect_names_from_options(entry.options),
@@ -232,6 +271,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoveeBLEConfigEntry) -> 
     _maybe_flag_music_mode_replaced(hass, entry)
     await _async_cleanup_legacy_entities(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await _async_update_editor_panel(hass)
     return True
 
 
@@ -241,6 +281,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: GoveeBLEConfigEntry) ->
         await effect_backend.preview.async_unload_device(entry.entry_id)
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         await entry.runtime_data.disconnect()
+        await _async_update_editor_panel(hass)
     elif effect_backend is not None:
         await effect_backend.preview.async_load_device(entry.entry_id)
     return unload_ok
@@ -260,3 +301,4 @@ async def async_remove_entry(hass: HomeAssistant, entry: GoveeBLEConfigEntry) ->
     ir.async_delete_issue(hass, DOMAIN, _unsupported_model_issue_id(entry))
     if entry.unique_id is not None:
         clear_availability_log_state(hass, entry.unique_id)
+    await _async_update_editor_panel(hass, excluding_entry_id=entry.entry_id)

--- a/custom_components/ha_govee_led_ble/__init__.py
+++ b/custom_components/ha_govee_led_ble/__init__.py
@@ -90,19 +90,9 @@ def _unsupported_model_issue_id(entry: GoveeBLEConfigEntry) -> str:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async_register_light_services(hass)
-    effects = await async_setup_effects(hass)
-    await async_register_editor_panel(
-        hass,
-        advanced_available=effects is not None,
-        show_in_sidebar=_effect_studio_sidebar_visible(hass),
-    )
+    await async_setup_effects(hass)
+    await _async_update_editor_panel(hass)
     return True
-
-
-def _entry_supports_effect_studio(entry: ConfigEntry[Any]) -> bool:
-    raw_model = entry.data.get(CONF_MODEL)
-    model = resolve_model(raw_model) if isinstance(raw_model, str) else None
-    return model is not None and bool(supported_effect_categories(model))
 
 
 def _effect_studio_sidebar_visible(
@@ -111,7 +101,10 @@ def _effect_studio_sidebar_visible(
     excluding_entry_id: str | None = None,
 ) -> bool:
     return any(
-        entry.entry_id != excluding_entry_id and entry.disabled_by is None and _entry_supports_effect_studio(entry)
+        entry.entry_id != excluding_entry_id
+        and entry.disabled_by is None
+        and isinstance(model := entry.data.get(CONF_MODEL), str)
+        and bool(supported_effect_categories(model))
         for entry in hass.config_entries.async_entries(DOMAIN)
     )
 
@@ -121,15 +114,14 @@ async def _async_update_editor_panel(
     *,
     excluding_entry_id: str | None = None,
 ) -> None:
-    if hass.is_stopping or not frontend.async_panel_exists(hass, EDITOR_PANEL_PATH):
+    if hass.is_stopping:
+        return
+    if not _effect_studio_sidebar_visible(hass, excluding_entry_id=excluding_entry_id):
+        frontend.async_remove_panel(hass, EDITOR_PANEL_PATH, warn_if_unknown=False)
         return
     await async_register_editor_panel(
         hass,
         advanced_available=get_effect_backend(hass) is not None,
-        show_in_sidebar=_effect_studio_sidebar_visible(
-            hass,
-            excluding_entry_id=excluding_entry_id,
-        ),
     )
 
 

--- a/custom_components/ha_govee_led_ble/const.py
+++ b/custom_components/ha_govee_led_ble/const.py
@@ -124,6 +124,16 @@ _H617X_PROFILE = ModelProfile(
 MODEL_PROFILES: dict[str, ModelProfile] = {
     "H617A": _H617X_PROFILE,
     "H617E": _H617X_PROFILE,
+    "H6076": ModelProfile(
+        "H6076 Lyra Floor Lamp",
+        wire_model="H617A",
+        state_readable=True,
+        supports_rgb=True,
+        supports_color_temperature=True,
+        min_color_temp_kelvin=2700,
+        max_color_temp_kelvin=6500,
+        whole_device_mask=0x007F,
+    ),
     "H6199": ModelProfile(
         "H6199 DreamView T1",
         wire_model="H6199",

--- a/custom_components/ha_govee_led_ble/coordinator.py
+++ b/custom_components/ha_govee_led_ble/coordinator.py
@@ -121,7 +121,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         address: str,
         model: str,
         *,
-        configuration_url: str,
+        configuration_url: str | None,
         effect_families: frozenset[str] | None = None,
         effect_categories: frozenset[str] | None = None,
         prefix_effect_names: bool = False,

--- a/custom_components/ha_govee_led_ble/editor.py
+++ b/custom_components/ha_govee_led_ble/editor.py
@@ -69,6 +69,7 @@ async def async_register_editor_panel(
     hass: HomeAssistant,
     *,
     advanced_available: bool = False,
+    show_in_sidebar: bool = True,
 ) -> None:
     """Register the stable Effect Studio sidebar panel."""
     domain_data = hass.data.setdefault(DOMAIN, {})
@@ -95,7 +96,7 @@ async def async_register_editor_panel(
             },
         },
         require_admin=False,
-        show_in_sidebar=True,
+        show_in_sidebar=show_in_sidebar,
         update=True,
     )
 

--- a/custom_components/ha_govee_led_ble/editor.py
+++ b/custom_components/ha_govee_led_ble/editor.py
@@ -69,7 +69,6 @@ async def async_register_editor_panel(
     hass: HomeAssistant,
     *,
     advanced_available: bool = False,
-    show_in_sidebar: bool = True,
 ) -> None:
     """Register the stable Effect Studio sidebar panel."""
     domain_data = hass.data.setdefault(DOMAIN, {})
@@ -96,7 +95,7 @@ async def async_register_editor_panel(
             },
         },
         require_admin=False,
-        show_in_sidebar=show_in_sidebar,
+        show_in_sidebar=True,
         update=True,
     )
 

--- a/custom_components/ha_govee_led_ble/effect_websocket.py
+++ b/custom_components/ha_govee_led_ble/effect_websocket.py
@@ -21,7 +21,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import DOMAIN, supported_effect_categories
 from .effect_backend import EffectBackend
 from .effect_catalogue import (
     custom_effect_catalogue_payload,
@@ -130,6 +130,11 @@ PREVIEW_TARGET_UNAVAILABLE_CODE = "preview_target_unavailable"
 _LOGGER = logging.getLogger(__name__)
 
 
+def _entry_supports_effect_studio(entry: ConfigEntry[Any]) -> bool:
+    model = getattr(entry.runtime_data, "model", None)
+    return isinstance(model, str) and bool(supported_effect_categories(model))
+
+
 @websocket_command({vol.Required("type"): WS_INFO})
 @callback
 def ws_editor_info(
@@ -147,7 +152,11 @@ async def ws_editor_devices(
     connection: ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    entries = [entry for entry in hass.config_entries.async_entries(DOMAIN) if entry.state is ConfigEntryState.LOADED]
+    entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state is ConfigEntryState.LOADED and _entry_supports_effect_studio(entry)
+    ]
     if len(entries) > MAX_EDITOR_DEVICES:
         connection.send_error(
             msg["id"],
@@ -173,7 +182,12 @@ async def ws_editor_device(
     msg: dict[str, Any],
 ) -> None:
     entry = hass.config_entries.async_get_entry(msg["config_entry_id"])
-    if entry is None or entry.domain != DOMAIN or entry.state is not ConfigEntryState.LOADED:
+    if (
+        entry is None
+        or entry.domain != DOMAIN
+        or entry.state is not ConfigEntryState.LOADED
+        or not _entry_supports_effect_studio(entry)
+    ):
         connection.send_error(msg["id"], "not_found", "target config entry is not loaded")
         return
     connection.send_result(

--- a/custom_components/ha_govee_led_ble/effect_websocket.py
+++ b/custom_components/ha_govee_led_ble/effect_websocket.py
@@ -130,11 +130,6 @@ PREVIEW_TARGET_UNAVAILABLE_CODE = "preview_target_unavailable"
 _LOGGER = logging.getLogger(__name__)
 
 
-def _entry_supports_effect_studio(entry: ConfigEntry[Any]) -> bool:
-    model = getattr(entry.runtime_data, "model", None)
-    return isinstance(model, str) and bool(supported_effect_categories(model))
-
-
 @websocket_command({vol.Required("type"): WS_INFO})
 @callback
 def ws_editor_info(
@@ -155,7 +150,7 @@ async def ws_editor_devices(
     entries = [
         entry
         for entry in hass.config_entries.async_entries(DOMAIN)
-        if entry.state is ConfigEntryState.LOADED and _entry_supports_effect_studio(entry)
+        if entry.state is ConfigEntryState.LOADED and supported_effect_categories(entry.runtime_data.model)
     ]
     if len(entries) > MAX_EDITOR_DEVICES:
         connection.send_error(
@@ -182,12 +177,7 @@ async def ws_editor_device(
     msg: dict[str, Any],
 ) -> None:
     entry = hass.config_entries.async_get_entry(msg["config_entry_id"])
-    if (
-        entry is None
-        or entry.domain != DOMAIN
-        or entry.state is not ConfigEntryState.LOADED
-        or not _entry_supports_effect_studio(entry)
-    ):
+    if entry is None or entry.domain != DOMAIN or entry.state is not ConfigEntryState.LOADED:
         connection.send_error(msg["id"], "not_found", "target config entry is not loaded")
         return
     connection.send_result(

--- a/custom_components/ha_govee_led_ble/light.py
+++ b/custom_components/ha_govee_led_ble/light.py
@@ -2,8 +2,9 @@
 
 # fmt: off
 import logging
-from collections.abc import Awaitable, Callable, Generator
+from collections.abc import Awaitable, Callable, Generator, Mapping
 from contextlib import contextmanager
+from dataclasses import dataclass
 from functools import partial
 from typing import Any
 from uuid import UUID, uuid4
@@ -23,7 +24,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -35,6 +36,7 @@ from .const import (
     EFFECT_FAMILY_MUSIC,
     EFFECT_FAMILY_SCENES,
     EFFECT_FAMILY_VIDEO,
+    ModelProfile,
     effect_category_for_content_kind,
 )
 from .control_arbiter import ControlIntent, async_control_intent
@@ -74,6 +76,20 @@ PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, slots=True)
+class _StaticColorRestoreData(ExtraStoredData):
+    color_mode: ColorMode
+    rgb_color: tuple[int, int, int] | None = None
+    color_temp_kelvin: int | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            ATTR_COLOR_MODE: self.color_mode.value,
+            ATTR_RGB_COLOR: list(self.rgb_color) if self.rgb_color is not None else None,
+            ATTR_COLOR_TEMP_KELVIN: self.color_temp_kelvin,
+        }
+
+
 def _coerce_rgb(raw: Any) -> tuple[int, int, int] | None:
     if not isinstance(raw, list | tuple) or len(raw) != 3:
         return None
@@ -85,6 +101,39 @@ def _coerce_rgb(raw: Any) -> tuple[int, int, int] | None:
         max(0, min(255, red)),
         max(0, min(255, green)),
         max(0, min(255, blue)),
+    )
+
+
+def _coerce_static_color(
+    attributes: Mapping[str, Any],
+    profile: ModelProfile,
+) -> _StaticColorRestoreData | None:
+    raw_mode = attributes.get(ATTR_COLOR_MODE)
+    if isinstance(raw_mode, ColorMode):
+        restored_mode = raw_mode
+    elif isinstance(raw_mode, str):
+        try:
+            restored_mode = ColorMode(raw_mode)
+        except ValueError:
+            return None
+    else:
+        return None
+    if restored_mode is ColorMode.RGB:
+        if not profile.supports_rgb or (restored_rgb := _coerce_rgb(attributes.get(ATTR_RGB_COLOR))) is None:
+            return None
+        return _StaticColorRestoreData(restored_mode, rgb_color=restored_rgb)
+    if restored_mode is not ColorMode.COLOR_TEMP or not profile.supports_color_temperature:
+        return None
+    try:
+        restored_kelvin = int(attributes[ATTR_COLOR_TEMP_KELVIN])
+    except KeyError, TypeError, ValueError:
+        return None
+    return _StaticColorRestoreData(
+        restored_mode,
+        color_temp_kelvin=max(
+            profile.min_color_temp_kelvin,
+            min(profile.max_color_temp_kelvin, restored_kelvin),
+        ),
     )
 
 
@@ -265,6 +314,17 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
             attrs["segment_state_source"] = self.coordinator.segment_state_source
         return attrs
 
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData | None:
+        if self._attr_color_mode is ColorMode.COLOR_TEMP and self.coordinator.color_temp_kelvin is not None:
+            return _StaticColorRestoreData(
+                ColorMode.COLOR_TEMP,
+                color_temp_kelvin=self.coordinator.color_temp_kelvin,
+            )
+        if self._attr_color_mode is ColorMode.RGB:
+            return _StaticColorRestoreData(ColorMode.RGB, rgb_color=self.coordinator.rgb_color)
+        return None
+
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         if self._effect_backend is not None:
@@ -372,37 +432,14 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
             return
         if last_state.attributes.get(ATTR_EFFECT) not in (None, EFFECT_OFF):
             return
-        raw_mode = last_state.attributes.get(ATTR_COLOR_MODE)
-        if isinstance(raw_mode, ColorMode):
-            restored_mode = raw_mode
-        elif isinstance(raw_mode, str):
-            try:
-                restored_mode = ColorMode(raw_mode)
-            except ValueError:
-                return
-        else:
+        restored = _coerce_static_color(last_state.attributes, coordinator.profile)
+        if restored is None and (extra_data := await self.async_get_last_extra_data()) is not None:
+            restored = _coerce_static_color(extra_data.as_dict(), coordinator.profile)
+        if restored is None:
             return
-        restored_rgb: tuple[int, int, int] | None = None
-        restored_kelvin: int | None = None
-        if restored_mode is ColorMode.RGB:
-            if not coordinator.profile.supports_rgb:
-                return
-            restored_rgb = _coerce_rgb(last_state.attributes.get(ATTR_RGB_COLOR))
-            if restored_rgb is None:
-                return
-        elif restored_mode is ColorMode.COLOR_TEMP:
-            if not coordinator.profile.supports_color_temperature:
-                return
-            try:
-                restored_kelvin = int(last_state.attributes[ATTR_COLOR_TEMP_KELVIN])
-            except KeyError, TypeError, ValueError:
-                return
-            restored_kelvin = max(
-                coordinator.profile.min_color_temp_kelvin,
-                min(coordinator.profile.max_color_temp_kelvin, restored_kelvin),
-            )
-        else:
-            return
+        restored_mode = restored.color_mode
+        restored_rgb = restored.rgb_color
+        restored_kelvin = restored.color_temp_kelvin
         if coordinator.segment_state_source == "observed":
             if (
                 restored_kelvin is not None

--- a/custom_components/ha_govee_led_ble/manifest.json
+++ b/custom_components/ha_govee_led_ble/manifest.json
@@ -27,6 +27,18 @@
             "local_name": "GVH_H617E*"
         },
         {
+            "local_name": "ihoment_H6076*"
+        },
+        {
+            "local_name": "Govee_H6076*"
+        },
+        {
+            "local_name": "GBK_H6076*"
+        },
+        {
+            "local_name": "GVH_H6076*"
+        },
+        {
             "local_name": "ihoment_H6199*"
         },
         {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,3 +147,16 @@ def mock_coordinator():
     return _make_coord(
         address="AA:BB:CC:DD:EE:FF", model="H617A", profile=MODEL_PROFILES["H617A"], is_on=False, effect=None
     )
+
+
+@pytest.fixture
+def mock_h6076_coordinator():
+    return _make_coord(
+        address="22:33:44:55:66:77",
+        model="H6076",
+        profile=MODEL_PROFILES["H6076"],
+        is_on=False,
+        effect=None,
+        segment_colors=[],
+        segment_brightness=[],
+    )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -23,6 +23,7 @@ M = "custom_components.ha_govee_led_ble.config_flow"
 SVC = BluetoothServiceInfo("ihoment_H617A_ABCD", "AA:BB:CC:DD:EE:FF", -60, {}, {}, [], "local")
 SVC_LOWER = BluetoothServiceInfo("ihoment_H617A_ABCD", "aa:bb:cc:dd:ee:ff", -60, {}, {}, [], "local")
 SVC_H617E = BluetoothServiceInfo("Govee_H617E_ABCD", "22:33:44:55:66:77", -60, {}, {}, [], "local")
+SVC_H6076 = BluetoothServiceInfo("Govee_H6076_ABCD", "33:44:55:66:77:88", -60, {}, {}, [], "local")
 SVC_UNSUPPORTED = BluetoothServiceInfo("SomeOtherDevice", "11:22:33:44:55:66", -60, {}, {}, [], "local")
 
 
@@ -55,6 +56,15 @@ async def test_bluetooth_discovery(hass: HomeAssistant, mock_manual_validation):
     r2 = await _confirm(hass, r)
     assert r2["type"] == FlowResultType.CREATE_ENTRY and r2["title"] == "Govee H617A"
     assert r2["data"][CONF_MODEL] == "H617A"
+    mock_manual_validation.assert_not_awaited()
+
+
+async def test_bluetooth_discovery_h6076(hass: HomeAssistant, mock_manual_validation):
+    result = await _init(hass, config_entries.SOURCE_BLUETOOTH, SVC_H6076)
+    assert result["type"] is FlowResultType.FORM
+    created = await _confirm(hass, result)
+    assert created["type"] is FlowResultType.CREATE_ENTRY
+    assert created["data"] == {CONF_MODEL: "H6076"}
     mock_manual_validation.assert_not_awaited()
 
 
@@ -242,6 +252,12 @@ _EM += [
     ("GVH_H617E_ABCD", "H617E"),
     ("Govee_H617A0_ABCD", None),
     ("Govee_H617AX_ABCD", None),
+    ("ihoment_H6076_ABCD", "H6076"),
+    ("Govee_H6076_ABCD", "H6076"),
+    ("GBK_H6076_ABCD", "H6076"),
+    ("GVH_H6076_ABCD", "H6076"),
+    ("Govee_H60760_ABCD", None),
+    ("Govee_H6076X_ABCD", None),
 ]
 
 
@@ -308,6 +324,46 @@ async def test_options_flow_aborts_for_unsupported_model(hass: HomeAssistant):
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_supported"
+
+
+async def test_options_flow_aborts_when_model_has_no_effect_options(hass: HomeAssistant):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MODEL: "H6076"}, unique_id=SVC_H6076.address)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_options"
+
+
+async def test_reconfigure_h6076_preserves_entry_identity(hass: HomeAssistant):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Govee H617A",
+        data={CONF_MODEL: "H617A"},
+        options={CONF_EFFECT_CATEGORIES: ["scenes", "effects"]},
+        unique_id=SVC_H6076.address,
+    )
+    entry.add_to_hass(hass)
+    original_entry_id = entry.entry_id
+
+    with (
+        patch(f"{M}.bluetooth.async_last_service_info", return_value=SVC_H6076),
+        patch.object(hass.config_entries, "async_schedule_reload") as reload_entry,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_RECONFIGURE, "entry_id": entry.entry_id},
+        )
+        updated = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_MODEL: "H6076"})
+
+    assert updated["type"] is FlowResultType.ABORT
+    assert entry.entry_id == original_entry_id
+    assert entry.unique_id == SVC_H6076.address
+    assert entry.title == "Govee H6076"
+    assert entry.data == {CONF_MODEL: "H6076"}
+    assert entry.options == {}
+    reload_entry.assert_called_once_with(entry.entry_id)
 
 
 async def test_reconfigure_preserves_entry_identity_and_clears_effect_options(hass: HomeAssistant):

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -47,6 +47,21 @@ def test_h617a_and_h617e_share_complete_feature_profile():
     assert wire_model("H617E") == "H617A"
 
 
+def test_h6076_profile_is_basic_and_fail_closed():
+    profile = MODEL_PROFILES["H6076"]
+    assert profile.state_readable
+    assert profile.supports_rgb and profile.supports_color_temperature
+    assert (profile.min_color_temp_kelvin, profile.max_color_temp_kelvin) == (2700, 6500)
+    assert not profile.supports_color_mode_readback
+    assert not profile.supports_custom_effects
+    assert not profile.supports_scenes
+    assert not profile.supports_music_mode
+    assert not profile.supports_segments
+    assert profile.whole_device_mask == 0x007F
+    assert wire_model("H6076") == "H617A"
+    assert protocol_model("H6076") == "H6076"
+
+
 def test_unknown_models_fail_closed():
     assert get_profile("nope") is UNSUPPORTED_PROFILE
     assert not UNSUPPORTED_PROFILE.supports_segments

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1406,6 +1406,28 @@ async def test_profile_without_colour_readback_rejects_colour_expectations(limit
     ensure.assert_not_awaited()
 
 
+async def test_h6076_refresh_all_uses_limited_readback_profile(hass):
+    coordinator = GoveeBLECoordinator(
+        hass,
+        "33:44:55:66:77:88",
+        "H6076",
+        configuration_url=_CONFIGURATION_URL,
+    )
+    coordinator._client = client = _c()
+
+    async def _reply(**kwargs) -> bool:
+        assert kwargs["query_color_mode"] is False
+        coordinator._notify_callback(None, bytearray(proto.build_packet(0xAA, 0x01, [0])))
+        coordinator._notify_callback(None, bytearray(proto.build_packet(0xAA, 0x04, [40])))
+        return True
+
+    with (
+        patch.object(coordinator, "_ensure_connected", new=AsyncMock(return_value=client)),
+        patch.object(coordinator, "_send_state_queries", new=AsyncMock(side_effect=_reply)),
+    ):
+        assert await coordinator.refresh_state(refresh_all=True, timeout=0.02)
+
+
 async def test_refresh_reply_timeout_starts_after_connection(coord):
     client = _c(disconnect=AsyncMock())
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2090,6 +2090,27 @@ def test_device_info_carries_versions_and_omits_connections(coord):
     assert "connections" not in info
 
 
+def test_device_info_clears_stale_configuration_url(hass):
+    coordinator = GoveeBLECoordinator(
+        hass,
+        "33:44:55:66:77:88",
+        "H6076",
+        configuration_url=None,
+    )
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=coordinator.address)
+    entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, coordinator.address)},
+        configuration_url="homeassistant://ha-govee-led-ble/editor/stale",
+    )
+
+    device = registry.async_get_or_create(config_entry_id=entry.entry_id, **coordinator.device_info)
+
+    assert device.configuration_url is None
+
+
 def test_device_info_replaces_a_stale_configuration_url(hass, coord):
     entry = MockConfigEntry(domain=DOMAIN, unique_id=coord.address)
     entry.add_to_hass(hass)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -81,6 +81,24 @@ async def test_surfaces_release_capability_evidence_without_hiding_planned_workf
     assert capabilities["workshop"]["verification_confidence"] == "selection_only"
 
 
+async def test_h6076_diagnostics_expose_basic_capability_boundary(mock_h6076_coordinator):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="22:33:44:55:66:77",
+        data={CONF_MODEL: "H6076"},
+    )
+    diag = await _run(_prep(mock_h6076_coordinator), entry)
+    coord = diag["coordinator"]
+
+    assert coord["supports_rgb"] is True
+    assert coord["supports_color_temperature"] is True
+    assert coord["color_temperature_range"] == {"minimum_kelvin": 2700, "maximum_kelvin": 6500}
+    assert coord["supports_color_mode_readback"] is False
+    assert coord["supports_custom_effects"] is False
+    assert coord["supports_segments"] is False
+    assert coord["release_capabilities"]["capabilities"] == []
+
+
 async def test_stale_experimental_option_ignored(mock_h6199_coordinator):
     """A leftover experimental option loads without error and drives no computed block."""
     entry = _entry(options={"experimental": {"timers": True, "diy": False}})

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -93,7 +93,7 @@ async def test_process_setup_hides_panel_without_capable_device(
 
     assert await async_setup(hass, {})
 
-    assert hass.data[frontend.DATA_PANELS][EDITOR_PANEL_PATH].show_in_sidebar is False
+    assert not frontend.async_panel_exists(hass, EDITOR_PANEL_PATH)
 
 
 async def test_panel_registration_is_idempotent_and_updates_configuration(
@@ -109,26 +109,11 @@ async def test_panel_registration_is_idempotent_and_updates_configuration(
     assert panel.config["_panel_custom"]["module_url"] == EDITOR_LOADER_MODULE_URL
 
 
-async def test_panel_registration_preserves_home_assistant_visibility_override(
-    hass: HomeAssistant,
-) -> None:
-    assert await async_setup_component(hass, "http", {})
-    overrides = hass.data.setdefault(frontend.DATA_PANELS_CONFIG, {})
-    overrides[EDITOR_PANEL_PATH] = {"show_in_sidebar": False}
-
-    await async_register_editor_panel(hass, show_in_sidebar=False)
-    await async_register_editor_panel(hass, show_in_sidebar=True)
-
-    panel = hass.data[frontend.DATA_PANELS][EDITOR_PANEL_PATH]
-    assert panel.show_in_sidebar is True
-    assert overrides == {EDITOR_PANEL_PATH: {"show_in_sidebar": False}}
-    assert panel.to_response(overrides[EDITOR_PANEL_PATH])["show_in_sidebar"] is False
-
-
 async def test_backend_storage_failure_keeps_stable_fallback_panel(
     hass: HomeAssistant,
     monkeypatch,
 ) -> None:
+    MockConfigEntry(domain=DOMAIN, data={CONF_MODEL: "H617A"}).add_to_hass(hass)
     assert await async_setup_component(hass, "http", {})
 
     async def fail(_hass):
@@ -150,6 +135,7 @@ async def test_newer_optional_store_keeps_stable_fallback_panel(
     hass: HomeAssistant,
     monkeypatch,
 ) -> None:
+    MockConfigEntry(domain=DOMAIN, data={CONF_MODEL: "H617A"}).add_to_hass(hass)
     assert await async_setup_component(hass, "http", {})
 
     async def fail(_hass):
@@ -170,6 +156,7 @@ async def test_invalid_development_url_does_not_break_panel_registration(
     hass: HomeAssistant,
     monkeypatch,
 ) -> None:
+    MockConfigEntry(domain=DOMAIN, data={CONF_MODEL: "H617A"}).add_to_hass(hass)
     monkeypatch.setenv(EDITOR_DEV_MODULE_URL_ENV, "not a URL")
     assert await async_setup_component(hass, "http", {})
 
@@ -206,6 +193,7 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
     hass_ws_client,
     monkeypatch,
 ) -> None:
+    MockConfigEntry(domain=DOMAIN, data={CONF_MODEL: "H617A"}).add_to_hass(hass)
     assert await async_setup_component(hass, "http", {})
     assert await async_setup_component(hass, "websocket_api", {})
     assert await async_setup(hass, {})
@@ -242,7 +230,6 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
         domain=DOMAIN,
         state=ConfigEntryState.LOADED,
         runtime_data=SimpleNamespace(model="H6076"),
-        title="Govee H6076",
     )
     registry_entry = MockConfigEntry(domain=DOMAIN, entry_id=entry.entry_id)
     registry_entry.add_to_hass(hass)
@@ -261,10 +248,7 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
         context.setattr(
             hass.config_entries,
             "async_get_entry",
-            lambda entry_id: next(
-                (candidate for candidate in (entry, unsupported_entry) if candidate.entry_id == entry_id),
-                None,
-            ),
+            lambda entry_id: entry if entry_id == entry.entry_id else None,
         )
         client = await hass_ws_client(hass)
         await client.send_json_auto_id({"type": WS_INFO})
@@ -280,13 +264,6 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
             }
         )
         selected_device = await client.receive_json()
-        await client.send_json_auto_id(
-            {
-                "type": WS_DEVICE,
-                "config_entry_id": unsupported_entry.entry_id,
-            }
-        )
-        unsupported_device = await client.receive_json()
         await client.send_json_auto_id(
             {
                 "type": WS_DEVICE_SUBSCRIBE,
@@ -315,8 +292,6 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
     assert len(devices["result"]["devices"]) == 1
     device = devices["result"]["devices"][0]
     refreshed_device = selected_device["result"]["device"]
-    assert unsupported_device["success"] is False
-    assert unsupported_device["error"]["code"] == "not_found"
     assert subscribed["success"] is True
     assert device_event["event"]["device"]["config_entry_id"] == entry.entry_id
     assert pushed_device_event["event"]["device"]["active_state"]["mode"] == "scene"

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -19,7 +19,7 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ha_govee_led_ble import async_setup
-from custom_components.ha_govee_led_ble.const import DOMAIN
+from custom_components.ha_govee_led_ble.const import CONF_MODEL, DOMAIN
 from custom_components.ha_govee_led_ble.coordinator import GoveeBLECoordinator
 from custom_components.ha_govee_led_ble.editor import (
     _EDITOR_MANIFEST,
@@ -63,6 +63,7 @@ def _clear_editor_development_module(monkeypatch) -> None:
 async def test_process_setup_registers_visible_advanced_stable_route(
     hass: HomeAssistant,
 ) -> None:
+    MockConfigEntry(domain=DOMAIN, data={CONF_MODEL: "H617A"}).add_to_hass(hass)
     assert await async_setup_component(hass, "http", {})
 
     assert await async_setup(hass, {})
@@ -81,6 +82,20 @@ async def test_process_setup_registers_visible_advanced_stable_route(
     assert get_effect_backend(hass) is not None
 
 
+@pytest.mark.parametrize("model", [None, "H6076"])
+async def test_process_setup_hides_panel_without_capable_device(
+    hass: HomeAssistant,
+    model: str | None,
+) -> None:
+    if model is not None:
+        MockConfigEntry(domain=DOMAIN, data={CONF_MODEL: model}).add_to_hass(hass)
+    assert await async_setup_component(hass, "http", {})
+
+    assert await async_setup(hass, {})
+
+    assert hass.data[frontend.DATA_PANELS][EDITOR_PANEL_PATH].show_in_sidebar is False
+
+
 async def test_panel_registration_is_idempotent_and_updates_configuration(
     hass: HomeAssistant,
 ) -> None:
@@ -92,6 +107,22 @@ async def test_panel_registration_is_idempotent_and_updates_configuration(
     panel = hass.data[frontend.DATA_PANELS][EDITOR_PANEL_PATH]
     assert panel.config is not None
     assert panel.config["_panel_custom"]["module_url"] == EDITOR_LOADER_MODULE_URL
+
+
+async def test_panel_registration_preserves_home_assistant_visibility_override(
+    hass: HomeAssistant,
+) -> None:
+    assert await async_setup_component(hass, "http", {})
+    overrides = hass.data.setdefault(frontend.DATA_PANELS_CONFIG, {})
+    overrides[EDITOR_PANEL_PATH] = {"show_in_sidebar": False}
+
+    await async_register_editor_panel(hass, show_in_sidebar=False)
+    await async_register_editor_panel(hass, show_in_sidebar=True)
+
+    panel = hass.data[frontend.DATA_PANELS][EDITOR_PANEL_PATH]
+    assert panel.show_in_sidebar is True
+    assert overrides == {EDITOR_PANEL_PATH: {"show_in_sidebar": False}}
+    assert panel.to_response(overrides[EDITOR_PANEL_PATH])["show_in_sidebar"] is False
 
 
 async def test_backend_storage_failure_keeps_stable_fallback_panel(
@@ -206,6 +237,13 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
         runtime_data=coordinator,
         title="Govee H617A",
     )
+    unsupported_entry = SimpleNamespace(
+        entry_id="h6076-entry",
+        domain=DOMAIN,
+        state=ConfigEntryState.LOADED,
+        runtime_data=SimpleNamespace(model="H6076"),
+        title="Govee H6076",
+    )
     registry_entry = MockConfigEntry(domain=DOMAIN, entry_id=entry.entry_id)
     registry_entry.add_to_hass(hass)
     light = er.async_get(hass).async_get_or_create(
@@ -218,12 +256,15 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
         context.setattr(
             hass.config_entries,
             "async_entries",
-            lambda domain=None: [entry] if domain in (None, DOMAIN) else [],
+            lambda domain=None: [entry, unsupported_entry] if domain in (None, DOMAIN) else [],
         )
         context.setattr(
             hass.config_entries,
             "async_get_entry",
-            lambda entry_id: entry if entry_id == entry.entry_id else None,
+            lambda entry_id: next(
+                (candidate for candidate in (entry, unsupported_entry) if candidate.entry_id == entry_id),
+                None,
+            ),
         )
         client = await hass_ws_client(hass)
         await client.send_json_auto_id({"type": WS_INFO})
@@ -239,6 +280,13 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
             }
         )
         selected_device = await client.receive_json()
+        await client.send_json_auto_id(
+            {
+                "type": WS_DEVICE,
+                "config_entry_id": unsupported_entry.entry_id,
+            }
+        )
+        unsupported_device = await client.receive_json()
         await client.send_json_auto_id(
             {
                 "type": WS_DEVICE_SUBSCRIBE,
@@ -264,8 +312,11 @@ async def test_container_process_contract_uses_production_panel_websocket_storag
     assert info["success"] is True
     assert info["result"]["api_version"] == EDITOR_API_VERSION
     assert library["result"] == {"generation": 0, "items": []}
+    assert len(devices["result"]["devices"]) == 1
     device = devices["result"]["devices"][0]
     refreshed_device = selected_device["result"]["device"]
+    assert unsupported_device["success"] is False
+    assert unsupported_device["error"]["code"] == "not_found"
     assert subscribed["success"] is True
     assert device_event["event"]["device"]["config_entry_id"] == entry.entry_id
     assert pushed_device_event["event"]["device"]["active_state"]["mode"] == "scene"

--- a/tests/test_effect_domain.py
+++ b/tests/test_effect_domain.py
@@ -652,6 +652,7 @@ def test_editor_contract_reports_first_slice_boundaries() -> None:
     h617a = device_effect_capabilities("entry-a", "H617A", "Test Light", 15)
     h6199 = device_effect_capabilities("entry-b", "H6199", "TV", 15)
     unknown = device_effect_capabilities("entry-c", "H9999", "Unknown", 0)
+    h6076 = device_effect_capabilities("entry-d", "H6076", "Floor Lamp", 0)
 
     assert api == {
         "api_version": EDITOR_API_VERSION,
@@ -678,6 +679,7 @@ def test_editor_contract_reports_first_slice_boundaries() -> None:
     assert h6199.advanced is CapabilityState.SUPPORTED
     assert h6199.to_dict()["readback"] == "scene_selector_for_user_effects"
     assert unknown.to_dict()["readback"] == "none"
+    assert h6076.to_dict()["readback"] == "none"
     assert all(
         capability is CapabilityState.UNSUPPORTED
         for capability in (

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,12 +1,13 @@
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 
 from custom_components.ha_govee_led_ble import (
     _async_cleanup_legacy_entities,
+    _effect_studio_sidebar_visible,
     async_remove_entry,
     async_setup,
     async_setup_entry,
@@ -35,7 +36,13 @@ def mock_last_service_info():
 
 
 def _entry(**kw):
-    d = dict(entry_id="test_entry_id", unique_id="AA:BB:CC:DD:EE:FF", data={CONF_MODEL: "H617A"}, options={})
+    d = dict(
+        entry_id="test_entry_id",
+        unique_id="AA:BB:CC:DD:EE:FF",
+        data={CONF_MODEL: "H617A"},
+        options={},
+        disabled_by=None,
+    )
     return MagicMock(**({**d, "domain": DOMAIN, "state": ConfigEntryState.LOADED, "runtime_data": None} | kw))
 
 
@@ -48,6 +55,7 @@ async def test_setup_entry(hass: HomeAssistant):
             return_value="homeassistant://ha-govee-led-ble/editor/test_entry_id",
         ) as build_url,
         patch("custom_components.ha_govee_led_ble._async_cleanup_legacy_entities", new_callable=AsyncMock) as cleanup,
+        patch("custom_components.ha_govee_led_ble._async_update_editor_panel", new_callable=AsyncMock) as update_panel,
         patch.object(hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock) as fwd,
     ):
         cls.return_value.async_config_entry_first_refresh = AsyncMock()
@@ -69,6 +77,25 @@ async def test_setup_entry(hass: HomeAssistant):
     assert entry.runtime_data is cls.return_value
     cleanup.assert_awaited_once_with(hass, entry)
     fwd.assert_awaited_once()
+    update_panel.assert_awaited_once_with(hass)
+
+
+async def test_setup_entry_omits_editor_link_for_h6076(hass: HomeAssistant):
+    entry = _entry(data={CONF_MODEL: "H6076"})
+    with (
+        patch("custom_components.ha_govee_led_ble.GoveeBLECoordinator", autospec=True) as cls,
+        patch("custom_components.ha_govee_led_ble.editor_url") as build_url,
+        patch("custom_components.ha_govee_led_ble._async_cleanup_legacy_entities", new_callable=AsyncMock),
+        patch("custom_components.ha_govee_led_ble._async_update_editor_panel", new_callable=AsyncMock),
+        patch.object(hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock),
+    ):
+        cls.return_value.async_config_entry_first_refresh = AsyncMock()
+        cls.return_value.profile = MODEL_PROFILES["H6076"]
+
+        assert await async_setup_entry(hass, entry) is True
+
+    assert cls.call_args.kwargs["configuration_url"] is None
+    build_url.assert_not_called()
 
 
 async def test_setup_entry_reconciles_loaded_coordinator_with_effect_cache(hass: HomeAssistant):
@@ -121,9 +148,16 @@ async def test_setup_entry_rejects_known_advertised_model_mismatch(hass: HomeAss
 @pytest.mark.parametrize("unload_ok,disc", [(True, "assert_awaited_once"), (False, "assert_not_awaited")])
 async def test_unload_entry(hass: HomeAssistant, unload_ok, disc):
     entry = _entry(runtime_data=MagicMock(disconnect=AsyncMock()))
-    with patch.object(hass.config_entries, "async_unload_platforms", new_callable=AsyncMock, return_value=unload_ok):
+    with (
+        patch("custom_components.ha_govee_led_ble._async_update_editor_panel", new_callable=AsyncMock) as update_panel,
+        patch.object(hass.config_entries, "async_unload_platforms", new_callable=AsyncMock, return_value=unload_ok),
+    ):
         assert await async_unload_entry(hass, entry) is unload_ok
     getattr(entry.runtime_data.disconnect, disc)()
+    if unload_ok:
+        update_panel.assert_awaited_once_with(hass)
+    else:
+        update_panel.assert_not_awaited()
 
 
 async def test_unload_entry_stops_preview_before_platforms_and_disconnect(hass: HomeAssistant):
@@ -143,11 +177,15 @@ async def test_unload_entry_stops_preview_before_platforms_and_disconnect(hass: 
             "custom_components.ha_govee_led_ble.get_effect_backend",
             return_value=MagicMock(preview=preview),
         ),
+        patch(
+            "custom_components.ha_govee_led_ble._async_update_editor_panel",
+            new=AsyncMock(side_effect=lambda _hass: order.append("panel")),
+        ),
         patch.object(hass.config_entries, "async_unload_platforms", side_effect=unload_platforms),
     ):
         assert await async_unload_entry(hass, entry) is True
 
-    assert order == ["preview", "platforms", "disconnect"]
+    assert order == ["preview", "platforms", "disconnect", "panel"]
 
 
 async def test_remove_entry_purges_all_device_scoped_effect_state(hass: HomeAssistant):
@@ -161,9 +199,12 @@ async def test_remove_entry_purges_all_device_scoped_effect_state(hass: HomeAssi
     backend.deployments.async_delete_device = AsyncMock()
     backend.user_state.async_clear_config_entry = AsyncMock()
 
-    with patch(
-        "custom_components.ha_govee_led_ble.get_effect_backend",
-        return_value=backend,
+    with (
+        patch(
+            "custom_components.ha_govee_led_ble.get_effect_backend",
+            return_value=backend,
+        ),
+        patch("custom_components.ha_govee_led_ble._async_update_editor_panel", new_callable=AsyncMock) as update_panel,
     ):
         await async_remove_entry(hass, entry)
 
@@ -174,6 +215,36 @@ async def test_remove_entry_purges_all_device_scoped_effect_state(hass: HomeAssi
     backend.deployments.async_delete_device.assert_awaited_once_with(entry.entry_id)
     backend.user_state.async_clear_config_entry.assert_awaited_once_with(entry.entry_id)
     assert hass.data[DOMAIN][AVAILABILITY_UNAVAILABLE_DATA_KEY] == set()
+    update_panel.assert_awaited_once_with(hass, excluding_entry_id=entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("models", "disabled", "visible"),
+    [
+        ([], set(), False),
+        (["H6076"], set(), False),
+        (["H617A"], set(), True),
+        (["H6076", "H6199"], set(), True),
+        (["H617A"], {0}, False),
+    ],
+)
+def test_effect_studio_sidebar_visibility_uses_enabled_configured_capabilities(
+    models,
+    disabled,
+    visible,
+):
+    hass = MagicMock()
+    entries = [
+        _entry(
+            entry_id=f"entry-{index}",
+            data={CONF_MODEL: model},
+            disabled_by=ConfigEntryDisabler.USER if index in disabled else None,
+        )
+        for index, model in enumerate(models)
+    ]
+    hass.config_entries.async_entries.return_value = entries
+
+    assert _effect_studio_sidebar_visible(hass) is visible
 
 
 async def test_cleanup_legacy_entities(hass: HomeAssistant):
@@ -276,7 +347,7 @@ async def test_async_setup_registers_effect_studio_sidebar_panel():
             },
         },
         require_admin=False,
-        show_in_sidebar=True,
+        show_in_sidebar=False,
         update=True,
     )
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,10 +21,8 @@ from custom_components.ha_govee_led_ble.const import (
 )
 from custom_components.ha_govee_led_ble.coordinator import AVAILABILITY_UNAVAILABLE_DATA_KEY
 from custom_components.ha_govee_led_ble.editor import (
-    EDITOR_ELEMENT_NAME,
     EDITOR_PANEL_PATH,
     EDITOR_ROUTE_SEGMENT,
-    _editor_module_url,
     editor_url,
 )
 
@@ -84,9 +82,7 @@ async def test_setup_entry_omits_editor_link_for_h6076(hass: HomeAssistant):
     entry = _entry(data={CONF_MODEL: "H6076"})
     with (
         patch("custom_components.ha_govee_led_ble.GoveeBLECoordinator", autospec=True) as cls,
-        patch("custom_components.ha_govee_led_ble.editor_url") as build_url,
         patch("custom_components.ha_govee_led_ble._async_cleanup_legacy_entities", new_callable=AsyncMock),
-        patch("custom_components.ha_govee_led_ble._async_update_editor_panel", new_callable=AsyncMock),
         patch.object(hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock),
     ):
         cls.return_value.async_config_entry_first_refresh = AsyncMock()
@@ -95,7 +91,6 @@ async def test_setup_entry_omits_editor_link_for_h6076(hass: HomeAssistant):
         assert await async_setup_entry(hass, entry) is True
 
     assert cls.call_args.kwargs["configuration_url"] is None
-    build_url.assert_not_called()
 
 
 async def test_setup_entry_reconciles_loaded_coordinator_with_effect_cache(hass: HomeAssistant):
@@ -177,15 +172,11 @@ async def test_unload_entry_stops_preview_before_platforms_and_disconnect(hass: 
             "custom_components.ha_govee_led_ble.get_effect_backend",
             return_value=MagicMock(preview=preview),
         ),
-        patch(
-            "custom_components.ha_govee_led_ble._async_update_editor_panel",
-            new=AsyncMock(side_effect=lambda _hass: order.append("panel")),
-        ),
         patch.object(hass.config_entries, "async_unload_platforms", side_effect=unload_platforms),
     ):
         assert await async_unload_entry(hass, entry) is True
 
-    assert order == ["preview", "platforms", "disconnect", "panel"]
+    assert order == ["preview", "platforms", "disconnect"]
 
 
 async def test_remove_entry_purges_all_device_scoped_effect_state(hass: HomeAssistant):
@@ -308,7 +299,7 @@ async def test_cleanup_legacy_entities(hass: HomeAssistant):
     assert registry.async_remove.call_count == 4 + len(removed_surface)
 
 
-async def test_async_setup_registers_effect_studio_sidebar_panel():
+async def test_async_setup_skips_effect_studio_without_capable_device():
     hass = MagicMock()
     hass.data = {}
     hass.async_add_executor_job = AsyncMock()
@@ -325,31 +316,8 @@ async def test_async_setup_registers_effect_studio_sidebar_panel():
 
     register_services.assert_called_once_with(hass)
     setup_effects.assert_awaited_once_with(hass)
-    hass.http.async_register_static_paths.assert_awaited_once()
-    (static_path,) = hass.http.async_register_static_paths.await_args.args[0]
-    assert static_path.url_path == f"/{DOMAIN}_static"
-    assert static_path.path.endswith("custom_components/ha_govee_led_ble/frontend")
-    assert static_path.cache_headers is False
-    register.assert_called_once_with(
-        hass,
-        component_name="custom",
-        sidebar_title="Govee Effect Studio",
-        sidebar_icon="mdi:palette",
-        sidebar_default_visible=True,
-        frontend_url_path=EDITOR_PANEL_PATH,
-        config={
-            "configuration_path": f"/config/integrations/integration/{DOMAIN}",
-            "_panel_custom": {
-                "name": EDITOR_ELEMENT_NAME,
-                "module_url": _editor_module_url(),
-                "embed_iframe": False,
-                "trust_external": False,
-            },
-        },
-        require_admin=False,
-        show_in_sidebar=False,
-        update=True,
-    )
+    hass.http.async_register_static_paths.assert_not_awaited()
+    register.assert_not_called()
 
 
 def test_editor_device_url_path_matches_registered_panel():

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -1566,6 +1566,7 @@ async def test_h6076_restores_static_colour_after_off_state_restart(
     mock_h6076_coordinator.rgb_color = (255, 255, 255)
     mock_h6076_coordinator.color_temp_kelvin = None
     restored = GoveeBLELight(mock_h6076_coordinator)
+    restored.async_write_ha_state = MagicMock()
     restored.async_get_last_state = AsyncMock(
         return_value=SimpleNamespace(
             attributes={
@@ -1584,6 +1585,16 @@ async def test_h6076_restores_static_colour_after_off_state_restart(
     assert mock_h6076_coordinator.color_temp_kelvin == color_temp_kelvin
     mock_h6076_coordinator.send_command.assert_not_awaited()
     mock_h6076_coordinator.async_set_updated_data.assert_called_once_with(mock_h6076_coordinator.data)
+
+    await restored.async_turn_on()
+
+    mock_h6076_coordinator.send_command.assert_awaited_once_with(build_power(True, "H6076"))
+    state_attributes = restored.state_attributes
+    assert state_attributes is not None
+    assert state_attributes["color_mode"] is color_mode
+    if color_mode is ColorMode.RGB:
+        assert state_attributes["rgb_color"] == rgb_color
+    assert state_attributes["color_temp_kelvin"] == color_temp_kelvin
 
 
 async def test_restore_static_colour_ignores_malformed_extra_data(light, mock_coordinator):

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -107,6 +107,20 @@ def test_basic_and_color_props(light, mock_coordinator):
     assert light.rgb_color is None and light.color_temp_kelvin == 4000
 
 
+async def test_h6076_exposes_only_basic_colour_controls(mock_h6076_coordinator):
+    light = GoveeBLELight(mock_h6076_coordinator)
+    light.async_write_ha_state = MagicMock()
+
+    assert light.supported_color_modes == {ColorMode.RGB, ColorMode.COLOR_TEMP}
+    assert light.min_color_temp_kelvin == 2700
+    assert light.max_color_temp_kelvin == 6500
+    assert light.effect_list == []
+
+    mock_h6076_coordinator.is_on = True
+    await light.async_turn_on(color_temp_kelvin=2000)
+    mock_h6076_coordinator.send_command.assert_awaited_once_with(build_color_temp(2700, "H6076"))
+
+
 def test_hidden_scene_family_does_not_project_internal_scene_state(
     light,
     mock_coordinator,

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -12,6 +12,7 @@ from bleak import BleakError
 from homeassistant.components.light import ColorMode
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.restore_state import RestoredExtraData
 
 from custom_components.ha_govee_led_ble.const import MODEL_PROFILES
 from custom_components.ha_govee_led_ble.coordinator_status import ParsedMode
@@ -1535,6 +1536,72 @@ async def test_restore_static_colour_temperature_as_last_known_presentation(ligh
     assert mock_coordinator.color_temp_kelvin == 4200
     assert light._attr_color_mode is ColorMode.COLOR_TEMP
     mock_coordinator.send_command.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("color_mode", "rgb_color", "color_temp_kelvin"),
+    [
+        (ColorMode.RGB, (12, 34, 56), None),
+        (ColorMode.COLOR_TEMP, (255, 255, 255), 4200),
+    ],
+)
+async def test_h6076_restores_static_colour_after_off_state_restart(
+    mock_h6076_coordinator,
+    color_mode,
+    rgb_color,
+    color_temp_kelvin,
+):
+    previous = GoveeBLELight(mock_h6076_coordinator)
+    previous._attr_color_mode = color_mode
+    mock_h6076_coordinator.rgb_color = rgb_color
+    mock_h6076_coordinator.color_temp_kelvin = color_temp_kelvin
+    stored = previous.extra_restore_state_data
+
+    assert stored is not None
+    stored_dict = stored.as_dict()
+    assert stored_dict["color_mode"] == color_mode.value
+    assert stored_dict["rgb_color"] == (list(rgb_color) if color_mode is ColorMode.RGB else None)
+    assert stored_dict["color_temp_kelvin"] == color_temp_kelvin
+
+    mock_h6076_coordinator.rgb_color = (255, 255, 255)
+    mock_h6076_coordinator.color_temp_kelvin = None
+    restored = GoveeBLELight(mock_h6076_coordinator)
+    restored.async_get_last_state = AsyncMock(
+        return_value=SimpleNamespace(
+            attributes={
+                "color_mode": None,
+                "rgb_color": None,
+                "color_temp_kelvin": None,
+            }
+        )
+    )
+    restored.async_get_last_extra_data = AsyncMock(return_value=RestoredExtraData(stored_dict))
+
+    await restored._async_restore_static_color()
+
+    assert restored._attr_color_mode is color_mode
+    assert mock_h6076_coordinator.rgb_color == rgb_color
+    assert mock_h6076_coordinator.color_temp_kelvin == color_temp_kelvin
+    mock_h6076_coordinator.send_command.assert_not_awaited()
+    mock_h6076_coordinator.async_set_updated_data.assert_called_once_with(mock_h6076_coordinator.data)
+
+
+async def test_restore_static_colour_ignores_malformed_extra_data(light, mock_coordinator):
+    light.async_get_last_state = AsyncMock(return_value=SimpleNamespace(attributes={"color_mode": None}))
+    light.async_get_last_extra_data = AsyncMock(
+        return_value=RestoredExtraData(
+            {
+                "color_mode": ColorMode.COLOR_TEMP.value,
+                "color_temp_kelvin": "invalid",
+            }
+        )
+    )
+
+    await light._async_restore_static_color()
+
+    assert light._attr_color_mode is ColorMode.RGB
+    assert mock_coordinator.color_temp_kelvin is None
+    mock_coordinator.async_set_updated_data.assert_not_called()
 
 
 async def test_restore_static_state_never_replaces_observed_segments(light, mock_coordinator):

--- a/tests/test_light_commands.py
+++ b/tests/test_light_commands.py
@@ -43,6 +43,15 @@ def test_whole_strip_colour_temperature_and_brightness() -> None:
     assert build_color_temp(12000)[7:9] == (9000).to_bytes(2, "big")
 
 
+def test_h6076_uses_its_whole_device_mask_and_kelvin_range() -> None:
+    colour = build_color_rgb(10, 20, 30, "H6076")
+    assert colour[12:14] == b"\x7f\x00"
+    parsed = parse_static_write(colour, "H6076")
+    assert parsed is not None and parsed.whole_strip
+    assert build_color_temp(2000, "H6076")[7:9] == (2700).to_bytes(2, "big")
+    assert build_color_temp(9000, "H6076")[7:9] == (6500).to_bytes(2, "big")
+
+
 def test_segment_numbering_and_masks() -> None:
     assert segments_to_mask([1]) == 0x0001
     assert segments_to_mask([3]) == 0x0004


### PR DESCRIPTION
## Summary

- add exact H6076 discovery on top of the stable v7.2.2 model-support foundation
- expose only power, brightness, whole-lamp RGB, and 2700–6500 K colour temperature
- require power/brightness readback while leaving colour state optimistic
- retain the last-known RGB or colour-temperature presentation across an off-state Home Assistant restart
- keep segments, scenes, music, custom effects, saved effects, and Effect Studio unavailable
- preserve same-entry reconfiguration from an old H617A selection

## Owner feedback

The RC1 candidate passed discovery, off-state setup, power, brightness, RGB, the full colour-temperature range, and reconnection after the Govee app.  It exposed one restore defect: Home Assistant cleared standard colour attributes while the light was off, so the optimistic H6076 colour presentation could not survive an off-state restart.

RC2 stores that static presentation through Home Assistant extra restore data without writing to the lamp during startup.  The reporter confirmed that both RGB and colour temperature survive separate Home Assistant restarts.  The `no_options` result remains expected because this Partial profile intentionally has no Effect Studio categories.

## Status

The reporter has confirmed every exposed control.  H6076 is ready for **Partial** stable support with colour-mode readback, segments, scenes, music, custom effects, saved effects, and Effect Studio remaining unavailable.

## Foundation

The model-neutral capability, reconfiguration, documentation, and prerelease foundation is already stable in [v7.2.2](https://github.com/teh-hippo/ha-govee-led-ble/releases/tag/v7.2.2).

Refs #247.  Prior evidence: #109 and #112.

## Effect Studio

Effect Studio stays out of the sidebar when none of the configured lights can use it.  H6076 also does not appear inside Studio or link to it.  When Studio is available, Home Assistant's normal hide and reorder settings still work.
