### PR TITLE
refactor: unify model capability architecture

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,8 @@
 
 - Full local preflight (matches CI):  
   `make check`
-- Completion gate: after making changes, `make check` must pass; if it fails, fix the issue and rerun until it passes, then capture any durable repo-specific lesson in these instructions.
+- Completion gate: after making changes, `make check` must pass; if it fails, fix the issue and rerun until it passes.
+  Record contributor-wide lessons in `CONTRIBUTING.md` and agent-only lessons here.
 - Canonical build:
   `make build`
 - Reproducible package:
@@ -14,54 +15,24 @@
 
 The Makefile owns build orchestration and the full local gate.
 
-## High-level architecture
+## Canonical contributor guidance
 
-- This is a Home Assistant custom integration (`domain: ha_govee_led_ble`) for local BLE control of supported Govee models (currently H617A and H6199).
-- `config_flow.py` handles discovery/manual setup, infers model from BLE local name, and creates config entries keyed by device address.
-- `__init__.py` creates one `GoveeBLECoordinator` per config entry, performs first refresh, removes legacy entities, and forwards setup to the platforms listed in its `PLATFORMS` constant.
-- The coordinator is split across `coordinator*.py`: BLE connect/reconnect lifecycle, notification subscription, keep-alive/state queries, optimistic state fields, and bounded raw packet logging for diagnostics.
-- Kaitai schemas own wire structure. Modules in `generated_protocol/` are ignored build outputs generated deterministically from them; focused handwritten modules retain semantic transforms and transport framing.
-- `light.py` is the primary control surface, with the custom services in `light_services.py`.
-- Effect Studio profiles own interdependent H6199 Video settings rather than duplicating them as standalone entities.
-- `scenes.py` loads the committed per-model scene snapshots used by light effect selection.
+Read and follow [`CONTRIBUTING.md`](../CONTRIBUTING.md) before planning or implementing changes.  It is the provider-agnostic source for:
 
-Name a module here only when something else in this file depends on knowing it exists. A full inventory rots: the last one still listed four platforms after there were seven.
+- project structure and model architecture;
+- new-model research and planning;
+- support quality and promotion;
+- Kaitai protocol ownership and speculative schemas;
+- exact-SKU scene catalogues;
+- repository non-goals; and
+- validation.
 
-## Key repository conventions
+Do not duplicate those rules here.  Update `CONTRIBUTING.md` when a contributor-wide invariant changes.
 
-- Model capabilities are declared in `const.py` via `ModelProfile` fields such as `supports_scenes`, `supports_video_mode`, `supports_white_balance`, `supports_blank_screen`, `static_readback_echoes_color`, and segment fields. New model behaviour should be wired through a profile field first, then entity setup. `supports_segments` and `supports_music_mode` are derived properties, so check before trying to set them.
-- Prefer root-cause refactoring over band-aid fixes; when behavior crosses layers, update shared paths instead of patching a single call site.
-- Treat changes holistically across capabilities, protocol encode/decode, coordinator state handling, entity/service wiring, diagnostics, and tests so behavior stays consistent.
-- Advanced Studio controls and saved-effect projection are capability-gated by the model profile and catalogue.
-- Do not add wire offsets, literals or enums to entity/coordinator code. Put structure in Kaitai and keep only semantic transforms, checksums and transport framing handwritten.
-- State writes are optimistic but guarded:
-  - `light.py` uses `_rollback()` snapshots plus `_refresh_with_retry()` verification for state-readable models.
-  - Effect Studio durable application uses the deployment engine's serialised prepare, write, verify and recovery path.
-- Effect names are normalized (`_normalize_effect_name`) before lookup/comparison; preserve this normalization path when adding new effects/services.
-- `make check` is the authoritative local validation flow and should stay aligned with `.github/workflows/validate.yml`.
+## Agent-specific reminders
 
-## Protocol source of truth
-
-- Captures are ground truth.
-- `tools/ble/kaitai/**/*.ksy` is the only wire-structure source. Do not restate offsets,
-  literals or enums elsewhere.
-- Evidence-backed H617A/H6199 schemas remain directly under `tools/ble/kaitai/`.
-  Exact-model hypotheses live under `tools/ble/kaitai/speculative/`, begin their top-level
-  `doc` with `SPECULATIVE`, and preserve uncertain bytes without invented validation.
-- Speculative runtime roots are allowed only when explicitly listed for an exact-model
-  prerelease. They do not qualify a model as Supported.
-- Unknown attributes follow official Kaitai style and omit `id`. `reserved` means known
-  unused. Unparsed transport chunks are not protocol unknowns.
-- `govee_shared.ksy` contains structures independently exercised through both models;
-  model-specific roots remain separate.
-- `tests/test_kaitai_protocol.py` exercises representative byte constants directly through
-  freshly generated parsers. Do not add a repository-specific fixture manifest or runner.
-- `scripts/generate-kaitai.sh` calls Kaitai Struct Compiler 0.11 directly and can locate
-  the pinned compiler through mise when it is not otherwise available. Java is an
-  unpinned development/CI runtime only.
-- Generated Python in `custom_components/ha_govee_led_ble/generated_protocol/` is
-  ignored and never edited manually.
-- After changing KSY, run `make protocol` and `make verify-protocol`.
-- Exact-SKU scene snapshots come from `tools/ble/refresh_scene_catalogues.py`. Catalogue
-  availability is official scene metadata, not proof of transport compatibility.
-- The public [`ios-ble-capture` methodology](https://github.com/teh-hippo/ios-ble-capture/blob/main/docs/methodology.md) describes capture, attribution and schema derivation.  This repository owns its KSY files and does not depend on that tool.
+- Use the four-section new-model plan from `CONTRIBUTING.md`; do not invent a provider-specific planning format.
+- Trace the complete affected path before editing, then prefer shared profile, adapter, coordinator, and test paths over model-specific duplicates.
+- Never edit generated protocol or frontend outputs manually.
+- Run focused existing checks while iterating and `make check` before declaring the final tree complete.
+- Run `make package` only when a distributable archive is requested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,36 @@ Open one GitHub issue for the exact model.  Include:
 
 Do not post the Bluetooth address, serial number, account details, or other unique identifiers.
 
+## Project structure
+
+- `custom_components/ha_govee_led_ble/const.py` owns the exact-model `ModelProfile` registry.  Profiles declare product capabilities and runtime policy; `wire_model` may reuse another model's protocol only where the bytes are compatible.
+- `tools/ble/kaitai/**/*.ksy` is the only BLE wire-structure source.  Generated modules under `generated_protocol/` are build outputs and are never edited manually.
+- `generated_protocol_adapter.py` connects generated structures to semantic builders and parsers.  Handwritten protocol code is limited to semantic transforms, checksums, and transport framing.
+- `coordinator*.py` owns connection lifecycle, queries, notifications, state, verification, and diagnostics.
+- `light.py`, `light_services.py`, and the model profile expose only capabilities declared for the configured device.
+- Effect Studio uses the same model profiles, capability contracts, and exact-SKU catalogues rather than a separate model architecture.
+- `scenes.py` loads committed exact-SKU Govee snapshots.  Catalogue data and BLE transport evidence remain separate.
+
+Every exact SKU has its own profile, support quality, catalogue identity, and product capability data.  Compatible models may share a Kaitai wire adapter, but do not share whole profiles or exact-SKU metadata.
+
+## Planning support for a new model
+
+Use the same short structure for human and agent plans:
+
+1. **Request and known context**
+2. **Research findings**
+3. **Candidate support scope**
+4. **Model-specific changes and owner checks**
+
+Research the exact device through available app behaviour, public sources, related projects, and supplied material.  Review contributed protocol files rather than accepting them as authoritative.  Aim for broad in-scope support, include defensible hypotheses as clearly speculative Kaitai, and preserve unknowns instead of inventing facts.
+
+The plan should describe only model-specific findings and work.  Link to this document instead of repeating repository architecture, protocol, support, release, or validation rules.
+
 ## Support lifecycle
 
 | Status | Meaning |
 | --- | --- |
-| Experimental | Prerelease-only candidate for an exact model, with a named device owner testing a limited capability set. |
+| Experimental | Prerelease-only exact-model implementation awaiting owner qualification. |
 | Partial | Stable owner-confirmed support with known gaps that remain intentionally unavailable. |
 | Compatible | Stable owner-confirmed support with no known compatibility issue in the exposed feature set, but incomplete model documentation. |
 | Supported | Fully documented support where every known feature is implemented or explicitly excluded and every enabled wire path has evidence-backed repository Kaitai coverage. |
@@ -25,9 +50,9 @@ Do not post the Bluetooth address, serial number, account details, or other uniq
 The progression is:
 
 1. A device owner requests an exact model and volunteers to test.
-2. A maintainer researches the model and enables only a conservative candidate feature set on a feature branch.
+2. A maintainer researches the complete known device surface and builds the broadest candidate that can be modelled without fabricating protocol facts.
 3. An immutable exact-SHA prerelease is published with a model suffix such as `.h617p`.
-4. The owner reports each exposed control as working or failing and attaches redacted diagnostics.
+4. The owner tries the available features and reports failures with redacted diagnostics.
 5. Failed capabilities are fixed or removed.
 6. The model moves to Partial or Compatible before stable merge.
 7. Supported is a later promotion after the model's features and explicit exclusions are completely documented.
@@ -35,30 +60,11 @@ The progression is:
 An Experimental profile that receives no owner confirmation is not merged as stable support.
 Prerelease versions are stamped only in the packaged artifact; feature branches retain the current stable source version so release-candidate metadata cannot leak into master.
 
-## Useful device-owner validation
+## Device-owner validation
 
-Test each exposed capability independently and report the visible result:
+The first prerelease request should stay short: provide the release link, explain installation or reconfiguration, ask the owner to try the available features, and request redacted diagnostics immediately after anything fails.  Include the privacy warning above.
 
-- setup and restart;
-- power;
-- several brightness levels;
-- RGB colours;
-- colour-temperature minimum, midpoint, and maximum;
-- state refresh;
-- idle disconnect and reconnect;
-- handoff from the Govee app back to Home Assistant; and
-- restoration of the original device state.
-
-Export integration diagnostics after the relevant phase.  Device owners are not expected to build the repository or run its developer test suite.
-
-For each tested action, report:
-
-1. the exact prerelease version and commit SHA;
-2. the action and expected visible result;
-3. the observed result;
-4. whether Home Assistant state readback matched;
-5. whether the original device state was restored; and
-6. diagnostics exported immediately after the action.
+Use a targeted follow-up checklist only when a result needs clarification.  Ask for the action, expected and observed result, Home Assistant state, restoration result, exact prerelease, and immediate diagnostics.  Device owners are not expected to build the repository or run its developer test suite.
 
 If the config entry never loads, enable debug logging for
 `custom_components.ha_govee_led_ble` and copy only the address-free protocol
@@ -77,10 +83,7 @@ The repository has two protocol evidence classes:
 - `tools/ble/kaitai/*.ksy` contains evidence-backed H617A, H6199, and independently verified shared structures.
 - `tools/ble/kaitai/speculative/*.ksy` contains exact-model hypotheses for Experimental, Partial, and Compatible work.
 
-When no official-app BLE capture is available, a contribution must still add either:
-
-- the minimum exact-model speculative KSY roots needed by the candidate; or
-- an explicit speculative compatibility alias when an evidence-backed root is reused byte-for-byte.
+When no official-app BLE capture is available, model the full known exact-model surface as far as the available evidence permits.  Every enabled wire path must use exact-model speculative KSY or a genuinely compatible evidence-backed root.
 
 Every speculative KSY must begin its top-level `doc` with `SPECULATIVE`, name
 the exact model and support issue, state the compatibility hypothesis, and list
@@ -118,7 +121,26 @@ hand-select a subset.  Catalogue availability proves scene identity and vendor
 payload data only; it does not prove transport, activation, upload, or readback
 compatibility.
 
-A committed snapshot may remain inert until the model profile enables scenes
-and `SCENE_ENTRIES` loads it.  Scene support additionally requires Kaitai
-coverage for the relevant wire paths, representative parameter parsing,
-owner-confirmed visible behaviour, and restoration testing.
+A committed snapshot may remain available as inert metadata while the model
+profile keeps scene controls disabled.  An Experimental candidate may expose
+scene activation when an exact-model transport hypothesis is represented in
+Kaitai.  Owner-confirmed visible behaviour and restoration are required before
+promotion.
+
+## Repository non-goals
+
+The repository may retain Kaitai schemas and protocol findings for excluded runtime features.  It does not expose:
+
+- Wi-Fi provisioning, cloud control, or account and network setup;
+- user-facing on-device timers or schedules;
+- host microphone capture or audio-derived control;
+- continuous host-driven BLE streaming for real-time audio or animation;
+- firmware or OTA updates;
+- manufacturer-style animated scene previews; or
+- camera calibration that depends on Govee Wi-Fi or cloud services.
+
+Onboard device-microphone modes, ordinary BLE commands, and bounded multipart effect uploads remain in scope.
+
+## Validation
+
+Before considering a contribution complete, run `make check` on the final tree and resolve any failures.  Run `make package` only when producing a distributable package.  Hassfest and HACS remain CI-enforced checks.

--- a/README.md
+++ b/README.md
@@ -9,49 +9,26 @@ Local BLE control and effect authoring for supported Govee lights from Home Assi
 
 ## Device support
 
-| Model | Status | Controls and limitations | Evidence |
-| --- | --- | --- | --- |
-| **H617A** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 83 scenes, 11 music modes and Effect Studio | Repository Kaitai schemas and physical qualification |
-| **H617E** | Compatible | Owner-confirmed H617A-compatible controls, scenes, effects and music modes; exact-model protocol documentation remains incomplete | Physical owner feedback and a speculative H617A compatibility alias |
-| **H6199** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 240 scenes, video and music modes, advanced controls and Effect Studio | Repository Kaitai schemas and physical qualification |
-| **H6076** | Partial | Confirmed power, brightness, RGB and 2700–6500 K colour temperature; colour-mode readback, segments, scenes, music and Effect Studio remain unavailable | [#247](https://github.com/teh-hippo/ha-govee-led-ble/issues/247) and a speculative H617A compatibility alias |
+| Model | Status | Controls and limitations |
+| --- | --- | --- |
+| **H617A** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 83 scenes, 11 music modes and Effect Studio |
+| **H6199** | Supported | Power, brightness, RGB, colour temperature, 15 segments, 240 scenes, video and music modes, advanced controls and Effect Studio |
+| **H617E** | Compatible | H617A-compatible controls, effects and music modes with its exact 240-scene catalogue and retained legacy scene-name compatibility; exact-model protocol documentation remains incomplete |
+| **H6076** | Partial | Power, brightness, RGB and 2700–6500 K colour temperature; colour-mode readback, segments, scenes, music and Effect Studio remain unavailable |
 
 **Experimental** is a model-specific prerelease awaiting owner confirmation.  **Partial** has confirmed controls plus known disabled gaps.  **Compatible** has no known issue in its exposed feature set but incomplete documentation.  **Supported** is fully documented, with every known feature implemented or explicitly excluded and evidence-backed Kaitai coverage for every enabled wire path.  See [CONTRIBUTING.md](CONTRIBUTING.md) for the request, speculative-schema, prerelease and promotion process.
 
 ## Effect Studio
 
-Govee Effect Studio is added to the Home Assistant sidebar when at least one enabled configured light supports it.  Users can hide or
-reorder the panel through Home Assistant's sidebar settings.  It provides local, model-aware effect editing without a Govee cloud account.
+Effect Studio appears in the Home Assistant sidebar when a configured light supports it.  Available scenes, effects, music, video, and editing controls follow the selected device's capabilities.
 
-| Model | Studio surfaces |
-| --- | --- |
-| H617A | Scenes, painted segments, single-layer effects, multi-layered effects, reactive music effects and advanced layered effects |
-| H617E | H617A-compatible scenes, effects and reactive music effects |
-| H6199 | Scenes, palette effects, reactive music effects, Movie and Game video profiles, and advanced layered effects |
+Administrators can preview, edit, apply, and save supported effects.  Other authenticated users can browse scenes and compatible saved effects in read-only mode.  Saved names are also available through the standard Home Assistant light effect selector.
 
-H6199 video profiles keep saturation, capture area, sound effects, softness, white balance, relative brightness and blank-screen behaviour together as one reusable effect.
-
-Administrators can edit effects and manage the shared saved-effect library.  Other authenticated users can browse scenes and compatible saved effects in read-only mode.
-
-### Using the editor
-
-1. Open **Govee Effect Studio** from the Home Assistant sidebar and choose a light.
-2. Select a category, then choose a built-in template or saved effect.
-3. Leave **Live** enabled to preview changes on the light, or disable it and use **Apply** when the draft is ready.
-4. Use **Save** for a built-in default, **Save As** for a named library effect, and **Reset** to restore the catalogue version.
-
-**Auto Save** persists committed changes to the selected built-in default or saved effect.  Editable built-ins can retain a per-light default, including native scenes, music profiles and H6199 video profiles.  The current unsaved draft is retained per device.
-
-Saved effect names appear in the standard Home Assistant light effect selector, so dashboards, scenes, scripts and automations use the same control path as Effect Studio.  The `ha_govee_led_ble.apply_custom_effect` entity action accepts either the current saved name or its stable effect ID and supports entity, device, area and label targets.
-
-Home Assistant light commands, scenes and automations take priority over Live previews.  Effect uploads and activation use one serialised operation, with verification and recovery on state-readable devices.
-
-Effect definitions are model-specific.  A strip cannot return the body uploaded by the Govee app, and the app provides no supported export format, so Effect Studio cannot import an arbitrary app-authored DIY effect directly.  The protocol boundary is documented in [#89](https://github.com/teh-hippo/ha-govee-led-ble/issues/89).
+Home Assistant commands take priority over live previews.  Effect uploads and activation are serialised with verification and recovery where the device supports readback.  Arbitrary app-authored DIY effects cannot be imported because the app provides no supported export format.
 
 ## Upgrade notes
 
 - An H6076 previously configured as H617A must be explicitly changed to H6076 through the integration's **Reconfigure** action.  The config entry and entity identity are preserved.
-- Version 7 adds Effect Studio while retaining the standard Home Assistant light effect selector introduced in version 6.
 - The standalone H617A scene-speed entity remains removed.  Edit scene speed in Effect Studio or select the native scene through the light effect selector.
 - Renaming a saved effect immediately changes its selector name.  Name-based automations must use the new name; the stable effect ID does not change.
 - Effect Studio stores the current saved definition rather than revision history.  Deleting a saved effect is permanent.
@@ -88,24 +65,23 @@ Use **Reconfigure** to correct the selected model while preserving the existing 
 
 ## Scope, non-goals, and expert tools
 
-The maintained product scope and per-model limitations are defined by the [device support table](#device-support).  The persistent H617A [`0xa3` register](https://github.com/teh-hippo/ha-govee-led-ble/issues/131) stores the app's gradual-colour-change switch, but the app explicitly classifies H617A as unsupported.  Paired physical comparisons found no visible effect, so the integration preserves the raw boolean and exposes no user-facing behaviour for it.
+The maintained product scope and per-model limitations are defined by the [device support table](#device-support).  H617A stores a gradual-colour-change boolean, but the app classifies the model as unsupported and physical comparisons found no visible effect, so the integration exposes no user-facing behaviour for it.
 
 Wi-Fi provisioning is not a maintained integration or contributor workflow.  The decoded H6199 [`a1 11` frame](tools/ble/kaitai/h6199_wifi_provision.ksy), [reassembled body](tools/ble/kaitai/h6199_wifi_body.ksy) and [`ee 11` result](tools/ble/kaitai/h6199_wifi_result.ksy) remain as tested protocol findings.
 
 The following are intentional non-goals for this integration:
 
-- on-device timers;
+- Wi-Fi provisioning, cloud control, and account or network setup;
+- user-facing on-device timers and schedules;
+- host microphone capture or audio-derived control;
+- continuous host-driven BLE streaming for real-time audio or animation;
+- firmware or OTA updates;
 - manufacturer-style animated scene previews;
-- phone-microphone music-stream injection;
-- firmware or OTA updates.
+- camera calibration that depends on Govee Wi-Fi or cloud services.
 
-The retained music-stream schema is decode-only evidence support.  It does not provide injection or playback control.
-
-Native H6199 camera calibration is unavailable from the current local interfaces.  The completed [camera-calibration investigation](https://github.com/teh-hippo/ha-govee-led-ble/issues/136) found that the required geometry exchange remains behind the manufacturer's trusted network service.
+The repository may retain Kaitai schemas and protocol findings for non-goals without exposing runtime controls.  Onboard device-microphone modes, ordinary BLE commands, and bounded multipart effect uploads remain supported.
 
 Additional models follow the request and qualification process in [CONTRIBUTING.md](CONTRIBUTING.md).  Cross-SKU evidence, Home Assistant quality-scale work, and restart-free integration updates remain separate programmes.
-
-The historical [7.0 UX completion evidence matrix](docs/completion-evidence.md) records that programme's issue dispositions, cleanup metrics, retained tests and release qualification.
 
 ## Development
 

--- a/custom_components/ha_govee_led_ble/const.py
+++ b/custom_components/ha_govee_led_ble/const.py
@@ -2,7 +2,8 @@
 
 import re
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from enum import StrEnum
 from typing import Any
 
 DOMAIN = "ha_govee_led_ble"
@@ -39,16 +40,49 @@ EFFECT_CATEGORY_CONTENT_KINDS = {
 _BLE_MODEL_PATTERN = re.compile(r"(?:ihoment|Govee|GBK|GVH)_(H[0-9A-Z]{4})(?:_|$)", re.IGNORECASE)
 
 
+class SupportQuality(StrEnum):
+    EXPERIMENTAL = "experimental"
+    PARTIAL = "partial"
+    COMPATIBLE = "compatible"
+    SUPPORTED = "supported"
+
+
+class ReadDomain(StrEnum):
+    POWER = "power"
+    BRIGHTNESS = "brightness"
+    COLOUR_MODE = "colour_mode"
+    MODE = "mode"
+    FIRMWARE = "firmware"
+    HARDWARE = "hardware"
+    SUBORDINATE_20 = "subordinate_20"
+    SUBORDINATE_21 = "subordinate_21"
+    DISPLAY_SETTING = "display_setting"
+    RELATIVE_BRIGHTNESS = "relative_brightness"
+    SEGMENTS = "segments"
+    OTHER = "other"
+
+
+_IDENTITY_READ_DOMAINS = frozenset(
+    {
+        ReadDomain.FIRMWARE,
+        ReadDomain.HARDWARE,
+        ReadDomain.SUBORDINATE_20,
+        ReadDomain.SUBORDINATE_21,
+    }
+)
+
+
 @dataclass(frozen=True)
 class ModelProfile:
     name: str
+    support_quality: SupportQuality = SupportQuality.EXPERIMENTAL
     wire_model: str | None = None
-    state_readable: bool = False
+    read_domains: frozenset[ReadDomain] = frozenset()
+    setup_required_read_domains: frozenset[ReadDomain] = frozenset()
     supports_rgb: bool = False
     supports_color_temperature: bool = False
     min_color_temp_kelvin: int = 2000
     max_color_temp_kelvin: int = 9000
-    supports_color_mode_readback: bool = False
     supports_custom_effects: bool = False
     supports_scenes: bool = False
     supports_video_mode: bool = False
@@ -56,6 +90,7 @@ class ModelProfile:
     supports_advanced_effects: bool = False
     supports_multi_layered_effects: bool = False
     supports_white_balance: bool = False
+    video_white_balance_default: int = 17
     supports_relative_brightness: bool = False
     supports_blank_screen: bool = False
     music_modes: tuple[str, ...] = ()
@@ -66,12 +101,43 @@ class ModelProfile:
     static_readback_echoes_color: bool = False
     whole_device_mask: int = 0
     segment_count: int = 0
+    segment_group_size: int = 0
     supports_segment_writes: bool = False
     connection_idle_timeout: float | None = None
+    scene_catalogue_sku: str | None = None
+    legacy_scene_catalogue_sku: str | None = None
+    advanced_scene_carrier: tuple[int, int] | None = None
+    default_effect_families_override: frozenset[str] | None = None
+    effect_readback: str = "none"
+
+    def __post_init__(self) -> None:
+        if not self.setup_required_read_domains <= self.read_domains:
+            raise ValueError("setup-required read domains must also be readable")
+
+    def can_read(self, domain: ReadDomain) -> bool:
+        return domain in self.read_domains
+
+    @property
+    def requires_notifications(self) -> bool:
+        return bool(self.read_domains)
+
+    @property
+    def state_readable(self) -> bool:
+        return bool(self.read_domains - _IDENTITY_READ_DOMAINS)
+
+    @property
+    def supports_color_mode_readback(self) -> bool:
+        return self.can_read(ReadDomain.COLOUR_MODE) or self.can_read(ReadDomain.MODE)
 
     @property
     def supports_segments(self) -> bool:
         return self.segment_count > 0 and self.supports_segment_writes
+
+    @property
+    def segment_group_count(self) -> int:
+        if not self.supports_segments or self.segment_group_size <= 0:
+            return 0
+        return (self.segment_count + self.segment_group_size - 1) // self.segment_group_size
 
     @property
     def supports_music_mode(self) -> bool:
@@ -95,13 +161,29 @@ MUSIC_MODE_SLUGS: dict[str, int] = {
 _H6199_MUSIC_MODES = ("energetic", "rhythm", "spectrum", "rolling")
 
 
-_H617X_PROFILE = ModelProfile(
-    "H617A/H617E LED Strip",
+_H617A_PROFILE = ModelProfile(
+    "H617A LED Strip",
+    support_quality=SupportQuality.SUPPORTED,
     wire_model="H617A",
-    state_readable=True,
+    read_domains=frozenset(
+        {
+            ReadDomain.POWER,
+            ReadDomain.BRIGHTNESS,
+            ReadDomain.COLOUR_MODE,
+            ReadDomain.FIRMWARE,
+            ReadDomain.HARDWARE,
+            ReadDomain.SEGMENTS,
+        }
+    ),
+    setup_required_read_domains=frozenset(
+        {
+            ReadDomain.POWER,
+            ReadDomain.BRIGHTNESS,
+            ReadDomain.COLOUR_MODE,
+        }
+    ),
     supports_rgb=True,
     supports_color_temperature=True,
-    supports_color_mode_readback=True,
     supports_custom_effects=True,
     supports_scenes=True,
     music_modes=tuple(MUSIC_MODE_SLUGS),
@@ -112,8 +194,12 @@ _H617X_PROFILE = ModelProfile(
     # H617A and H617E expose fifteen segments through five explicit aa a5 query groups of three.
     # Segment writes ACK normally but do not publish updated groups without those queries.
     segment_count=15,
+    segment_group_size=3,
     supports_segment_writes=True,
     connection_idle_timeout=3.0,
+    scene_catalogue_sku="H617A",
+    advanced_scene_carrier=(1013, 11836),
+    effect_readback="diy_code_only",
     # supports_white_brightness stays false because static subcommand 0x02 is segment-relative
     # brightness, not the level of a white colour-temperature mode. It compounds with master
     # brightness and is exposed through set_segment_brightness, including all-segment writes;
@@ -122,25 +208,64 @@ _H617X_PROFILE = ModelProfile(
 
 
 MODEL_PROFILES: dict[str, ModelProfile] = {
-    "H617A": _H617X_PROFILE,
-    "H617E": _H617X_PROFILE,
+    "H617A": _H617A_PROFILE,
+    "H617E": replace(
+        _H617A_PROFILE,
+        name="H617E LED Strip",
+        support_quality=SupportQuality.COMPATIBLE,
+        scene_catalogue_sku="H617E",
+        legacy_scene_catalogue_sku="H617A",
+        advanced_scene_carrier=(29884, 41599),
+    ),
     "H6076": ModelProfile(
         "H6076 Lyra Floor Lamp",
+        support_quality=SupportQuality.PARTIAL,
         wire_model="H617A",
-        state_readable=True,
+        read_domains=frozenset(
+            {
+                ReadDomain.POWER,
+                ReadDomain.BRIGHTNESS,
+                ReadDomain.FIRMWARE,
+                ReadDomain.HARDWARE,
+            }
+        ),
+        setup_required_read_domains=frozenset({ReadDomain.POWER, ReadDomain.BRIGHTNESS}),
         supports_rgb=True,
         supports_color_temperature=True,
         min_color_temp_kelvin=2700,
         max_color_temp_kelvin=6500,
         whole_device_mask=0x007F,
+        scene_catalogue_sku="H6076",
     ),
     "H6199": ModelProfile(
         "H6199 DreamView T1",
+        support_quality=SupportQuality.SUPPORTED,
         wire_model="H6199",
-        state_readable=True,
+        read_domains=frozenset(
+            {
+                ReadDomain.POWER,
+                ReadDomain.BRIGHTNESS,
+                ReadDomain.COLOUR_MODE,
+                ReadDomain.FIRMWARE,
+                ReadDomain.HARDWARE,
+                ReadDomain.SUBORDINATE_20,
+                ReadDomain.SUBORDINATE_21,
+                ReadDomain.DISPLAY_SETTING,
+                ReadDomain.RELATIVE_BRIGHTNESS,
+                ReadDomain.SEGMENTS,
+            }
+        ),
+        setup_required_read_domains=frozenset(
+            {
+                ReadDomain.POWER,
+                ReadDomain.BRIGHTNESS,
+                ReadDomain.COLOUR_MODE,
+                ReadDomain.DISPLAY_SETTING,
+                ReadDomain.RELATIVE_BRIGHTNESS,
+            }
+        ),
         supports_rgb=True,
         supports_color_temperature=True,
-        supports_color_mode_readback=True,
         supports_custom_effects=True,
         supports_scenes=True,
         supports_video_mode=True,
@@ -159,8 +284,13 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
         # queries. Kelvin remains last-known while its RGB companion matches.
         # Fifteen segment bits are independently writable. The aa 40 value 38 is not a segment count.
         segment_count=15,
+        segment_group_size=4,
         # Colour and brightness writes are observed through four explicit aa a5 query groups.
         supports_segment_writes=True,
+        scene_catalogue_sku="H6199",
+        advanced_scene_carrier=(29884, 41599),
+        default_effect_families_override=frozenset({EFFECT_FAMILY_VIDEO}),
+        effect_readback="scene_selector_for_user_effects",
     ),
 }
 
@@ -260,10 +390,10 @@ def effect_category_for_content_kind(content_kind: str) -> str | None:
 
 
 def default_effect_families(model: str) -> frozenset[str]:
+    profile = get_profile(model)
     supported = supported_effect_families(model)
-    if model == "H6199":
-        return frozenset({EFFECT_FAMILY_VIDEO}) & supported
-    return supported
+    requested = profile.default_effect_families_override
+    return supported if requested is None else requested & supported
 
 
 def effect_families_from_options(model: str, options: Mapping[str, Any]) -> frozenset[str]:

--- a/custom_components/ha_govee_led_ble/coordinator.py
+++ b/custom_components/ha_govee_led_ble/coordinator.py
@@ -21,6 +21,7 @@ from .ble_device_resolver import BLEDeviceResolver
 from .const import (
     DOMAIN,
     MUSIC_MODE_SLUGS,
+    ReadDomain,
     default_effect_categories,
     default_effect_families,
     get_profile,
@@ -63,7 +64,7 @@ from .native_profile_controls import (
     apply_white_balance,
 )
 from .native_scenes import build_native_scene_packets
-from .scenes import MODEL_SCENES
+from .scenes import MODEL_SCENES, canonical_scene_key, resolve_scene_code
 from .transport import READ_UUID, WRITE_UUID
 
 EFFECT_SEQUENCE_ATTEMPTS = 3
@@ -103,6 +104,7 @@ _COLOR_EXPECTATION_FIELDS = frozenset(
     (
         "color_mode",
         "effect",
+        "scene_code",
         "unknown_scene_code",
         "rgb_color",
         "color_temp_kelvin",
@@ -239,6 +241,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             rgb_color=self.rgb_color,
             color_temp_kelvin=self.color_temp_kelvin,
             effect=self.effect,
+            scene_code=self.scene_code,
             diy_code=self.diy_code,
             music_mode=self.music_mode,
             video_mode=self.video_mode,
@@ -317,18 +320,36 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             await self.send_command(build_h617a_diy_activation(state.diy_code))
             self.diy_code = state.diy_code
             return self.profile.state_readable and await self.refresh_state() and self.diy_code == state.diy_code
-        if state.mode == "scene" and state.effect is not None:
-            scene = MODEL_SCENES.get(self.model, {}).get(state.effect)
-            if scene is None:
+        if state.mode == "scene" and (state.effect is not None or state.scene_code is not None):
+            resolved = (
+                resolve_scene_code(
+                    self.model,
+                    state.scene_code,
+                    preferred_key=state.effect,
+                )
+                if state.scene_code is not None
+                else None
+            )
+            if resolved is not None:
+                scene_name, scene = resolved
+            elif state.effect is not None:
+                scene_name = canonical_scene_key(self.model, state.effect)
+                candidate = MODEL_SCENES.get(self.model, {}).get(scene_name)
+                if candidate is None:
+                    return False
+                scene = candidate
+            else:
                 return False
             packets = build_native_scene_packets(self.model, scene)
             for packet in packets:
                 await self.send_command(packet)
             self.is_on = True
-            self.effect = state.effect
+            self.color_mode = ParsedMode.SCENE
+            self.effect = scene_name
+            self._scene_code = scene.code
             self.diy_code = None
             self.music_mode = self.video_mode = "off"
-            return self.profile.state_readable and await self.refresh_state(expected_effect=state.effect)
+            return self.profile.state_readable and await self.refresh_state(expected_scene_code=scene.code)
         if state.mode == "music" and state.music_mode in self.profile.music_modes:
             self.install_music_profile_state(
                 mode=state.music_mode,
@@ -361,17 +382,6 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             self.video_sound_effects = state.video_sound_effects
             self.video_sound_effects_softness = state.video_sound_effects_softness
             return await apply_active_video_mode(self)
-        if state.mode == "scene" and state.effect is not None:
-            scene = MODEL_SCENES[self.model].get(state.effect)
-            if scene is None:
-                return False
-            packets = build_native_scene_packets(self.model, scene)
-            for packet in packets:
-                await self.send_command(packet)
-            self.effect = state.effect
-            self.diy_code = None
-            self.music_mode = self.video_mode = "off"
-            return self.profile.state_readable and await self.refresh_state(expected_effect=state.effect)
         if state.mode != "colour":
             return False
         await self.send_command(build_power(True, self.model))
@@ -415,6 +425,10 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             reset_red if self.white_balance_red is None else self.white_balance_red,
             reset_blue if self.white_balance_blue is None else self.white_balance_blue,
         )
+
+    @property
+    def scene_code(self) -> int | None:
+        return self._scene_code if self.color_mode is ParsedMode.SCENE else None
 
     @property
     def unknown_scene_code(self) -> int | None:
@@ -503,6 +517,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
                     previous_client = self._client
                     refreshed = await self.refresh_state(
                         refresh_all=True,
+                        required_domains=self.profile.setup_required_read_domains,
                     )
                     client = self._client
                     if not refreshed or client is None:
@@ -542,7 +557,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             disconnected_callback=self._disconnected_callback,
         )
         self._reset_disconnect_timer()
-        if self.profile.state_readable:
+        if self.profile.requires_notifications:
             try:
                 await self._start_notify()
                 await self._send_identity_queries()
@@ -612,7 +627,8 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         await self._client.start_notify(READ_UUID, self._notify_callback)
         self._notify_started_monotonic = time.monotonic()
         self._last_rx_monotonic = None
-        self._start_keep_alive()
+        if self.profile.state_readable:
+            self._start_keep_alive()
 
     def _receive_is_stale(self) -> bool:
         baseline = self._last_rx_monotonic
@@ -628,9 +644,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
 
     @property
     def _segment_group_count(self) -> int:
-        if not self.profile.supports_segments:
-            return 0
-        return 4 if self.model == "H6199" else 5
+        return self.profile.segment_group_count
 
     def mark_segment_state_optimistic(
         self,
@@ -664,7 +678,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
     def _apply_segment_group(self, generated: Any) -> tuple[str, ...]:
         group = int(generated.body.group)
         records = generated.body.segments
-        group_size = 4 if self.model == "H6199" else 3
+        group_size = self.profile.segment_group_size
         offset = (group - 1) * group_size
         if offset < 0 or offset + len(records) > self.profile.segment_count:
             raise ValueError("segment group exceeds model segment count")
@@ -765,9 +779,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         # Track the device's scene independently from Home Assistant's configured effect-list projection.
         scene_effect = parsed.effect if parsed.effect in self.scene_name_set else None
         # A scene we cannot name still leaves the light running something, and effect has to stay
-        # None because HA rejects one outside effect_list. Keep the raw id so the state is honest
-        # rather than silently claiming nothing is on. None for every other mode, so this one
-        # assignment cannot leave a stale code behind.
+        # None because HA rejects one outside effect_list.
         unknown_scene_code = parsed.scene_code if scene_effect is None else None
         observed: list[str] = ["color_mode"]
         accept_parameters = True
@@ -802,11 +814,12 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         elif parsed.mode is ParsedMode.SCENE:
             values = {
                 "effect": scene_effect,
+                "scene_code": parsed.scene_code,
                 "unknown_scene_code": unknown_scene_code,
             }
             if self._accept_expected_values(values):
                 self.effect = scene_effect
-                self._scene_code = unknown_scene_code
+                self._scene_code = parsed.scene_code
                 self.music_mode, self.video_mode = "off", "off"
                 self.diy_code = None
                 observed.extend(values)
@@ -1001,26 +1014,36 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             return False
         try:
             queries: list[bytes] = []
-            if query_power:
+            if query_power and self.profile.can_read(ReadDomain.POWER):
                 queries.append(build_power_query(self.model))
-            if query_brightness:
+            if query_brightness and self.profile.can_read(ReadDomain.BRIGHTNESS):
                 queries.append(build_brightness_query(self.model))
-            if query_color_mode:
+            if query_color_mode and self.profile.supports_color_mode_readback:
                 queries.append(build_colour_mode_query(self.model))
             full_query = query_power and query_brightness and query_color_mode
-            if self.profile.supports_white_balance and (
-                query_white_balance if query_white_balance is not None else full_query
+            if (
+                self.profile.can_read(ReadDomain.DISPLAY_SETTING)
+                and self.profile.supports_white_balance
+                and (query_white_balance if query_white_balance is not None else full_query)
             ):
                 queries.append(build_h6199_white_balance_query())
-            if self.profile.supports_blank_screen and (
-                query_blank_screen if query_blank_screen is not None else full_query
+            if (
+                self.profile.can_read(ReadDomain.DISPLAY_SETTING)
+                and self.profile.supports_blank_screen
+                and (query_blank_screen if query_blank_screen is not None else full_query)
             ):
                 queries.append(build_h6199_blank_screen_query())
-            if self.profile.supports_relative_brightness and (
-                query_relative_brightness if query_relative_brightness is not None else full_query
+            if (
+                self.profile.can_read(ReadDomain.RELATIVE_BRIGHTNESS)
+                and self.profile.supports_relative_brightness
+                and (query_relative_brightness if query_relative_brightness is not None else full_query)
             ):
                 queries.append(build_h6199_relative_brightness_query())
-            if self.profile.supports_segments and (query_segments if query_segments is not None else full_query):
+            if (
+                self.profile.can_read(ReadDomain.SEGMENTS)
+                and self.profile.supports_segments
+                and (query_segments if query_segments is not None else full_query)
+            ):
                 self._segment_groups_observed.clear()
                 self._segment_query_colors = list(self.segment_colors)
                 self._segment_query_brightness = list(self.segment_brightness)
@@ -1042,17 +1065,15 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         """
         if not self._client or not self._client.is_connected:
             return
-        candidates = [
-            (build_hardware_query(self.model), self.hw_version),
-            (build_firmware_query(self.model), self.fw_version),
-        ]
-        if self.model == "H6199":
-            candidates.extend(
-                (
-                    (build_h6199_subordinate_query(0x20), self.subordinate_20_version),
-                    (build_h6199_subordinate_query(0x21), self.subordinate_21_version),
-                )
-            )
+        candidates: list[tuple[bytes, str | None]] = []
+        if self.profile.can_read(ReadDomain.HARDWARE):
+            candidates.append((build_hardware_query(self.model), self.hw_version))
+        if self.profile.can_read(ReadDomain.FIRMWARE):
+            candidates.append((build_firmware_query(self.model), self.fw_version))
+        if self.profile.can_read(ReadDomain.SUBORDINATE_20):
+            candidates.append((build_h6199_subordinate_query(0x20), self.subordinate_20_version))
+        if self.profile.can_read(ReadDomain.SUBORDINATE_21):
+            candidates.append((build_h6199_subordinate_query(0x21), self.subordinate_21_version))
         queries = [q for q, value in candidates if value is None]
         try:
             for query in queries:
@@ -1062,10 +1083,15 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             _LOGGER.debug("Identity query failed for %s", self.address)
 
     def _identity_incomplete(self) -> bool:
-        return (
-            self.fw_version is None
-            or self.hw_version is None
-            or (self.model == "H6199" and (self.subordinate_20_version is None or self.subordinate_21_version is None))
+        return any(
+            value is None
+            for domain, value in (
+                (ReadDomain.FIRMWARE, self.fw_version),
+                (ReadDomain.HARDWARE, self.hw_version),
+                (ReadDomain.SUBORDINATE_20, self.subordinate_20_version),
+                (ReadDomain.SUBORDINATE_21, self.subordinate_21_version),
+            )
+            if self.profile.can_read(domain)
         )
 
     async def _wait_for_revisions(
@@ -1100,6 +1126,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         self,
         *,
         expected_effect: str | None = None,
+        expected_scene_code: int | None = None,
         expected_on: bool | None = None,
         expected_brightness: int | None = None,
         expected_music_mode: str | None = None,
@@ -1119,6 +1146,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         refresh_display_settings: bool = False,
         refresh_relative_brightness: bool = False,
         refresh_all: bool = False,
+        required_domains: frozenset[ReadDomain] | None = None,
         timeout: float = 2.0,
     ) -> bool:
         if not self.profile.state_readable:
@@ -1127,6 +1155,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             field: value
             for field, value in (
                 ("effect", expected_effect),
+                ("scene_code", expected_scene_code),
                 ("is_on", expected_on),
                 ("brightness_pct", expected_brightness),
                 ("music_mode", expected_music_mode),
@@ -1161,6 +1190,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             )
         color_expectations = (
             expected_effect,
+            expected_scene_code,
             expected_music_mode,
             expected_music_sensitivity,
             expected_music_calm,
@@ -1187,6 +1217,9 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         if refresh_all:
             query_power = query_brightness = True
             query_color = self.profile.supports_color_mode_readback
+            query_white_balance = self.profile.supports_white_balance
+            query_blank_screen = self.profile.supports_blank_screen
+            query_relative_brightness = self.profile.supports_relative_brightness
         if not any(
             (
                 query_power,
@@ -1202,15 +1235,16 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         queried_domains = {
             domain
             for domain, enabled in (
-                (StatusDomain.POWER, query_power),
-                (StatusDomain.BRIGHTNESS, query_brightness),
-                (StatusDomain.COLOUR_MODE, query_color),
-                (StatusDomain.DISPLAY_SETTING, query_white_balance or query_blank_screen),
-                (StatusDomain.RELATIVE_BRIGHTNESS, query_relative_brightness),
+                (ReadDomain.POWER, query_power),
+                (ReadDomain.BRIGHTNESS, query_brightness),
+                (ReadDomain.COLOUR_MODE, query_color),
+                (ReadDomain.DISPLAY_SETTING, query_white_balance or query_blank_screen),
+                (ReadDomain.RELATIVE_BRIGHTNESS, query_relative_brightness),
             )
-            if enabled
+            if enabled and self.profile.can_read(domain)
         }
-        initial_domain_baselines = {domain: self._domain_revisions.get(domain, 0) for domain in queried_domains}
+        awaited_domains = queried_domains if required_domains is None else queried_domains & required_domains
+        initial_domain_baselines = {domain: self._domain_revisions.get(domain, 0) for domain in awaited_domains}
         current_intent = self._control_arbiter.current_task_intent
         intent = ControlIntent.USER if current_intent is None else current_intent
         async with async_control_intent(self, intent):
@@ -1219,7 +1253,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             deadline = time.monotonic() + timeout
             for attempt in range(2):
                 field_baselines = {field: self._field_revisions.get(field, 0) for field in expectations}
-                domain_baselines = {domain: self._domain_revisions.get(domain, 0) for domain in queried_domains}
+                domain_baselines = {domain: self._domain_revisions.get(domain, 0) for domain in awaited_domains}
                 async with self._lock:
                     if self._client is not client:
                         return False
@@ -1402,6 +1436,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
                 {
                     "color_mode",
                     "effect",
+                    "scene_code",
                     "unknown_scene_code",
                     "diy_code",
                     "music_mode",

--- a/custom_components/ha_govee_led_ble/coordinator_base.py
+++ b/custom_components/ha_govee_led_ble/coordinator_base.py
@@ -64,6 +64,7 @@ class _CoordinatorBase(DataUpdateCoordinator[dict[str, Any]]):
             self,
             *,
             expected_effect: str | None = None,
+            expected_scene_code: int | None = None,
             expected_on: bool | None = None,
         ) -> bool: ...
 

--- a/custom_components/ha_govee_led_ble/coordinator_modes.py
+++ b/custom_components/ha_govee_led_ble/coordinator_modes.py
@@ -16,7 +16,7 @@ from .light_commands import (
 )
 from .music_commands import build_music_params
 from .native_scenes import build_native_scene_packets
-from .scenes import MODEL_SCENES
+from .scenes import MODEL_SCENES, SceneEntry, canonical_scene_key
 
 
 @dataclass(frozen=True)
@@ -146,7 +146,7 @@ class _ActiveModeMixin(_CoordinatorBase):
 
     @property
     def scene_name_set(self) -> frozenset[str]:
-        return frozenset(MODEL_SCENES[self.model])
+        return frozenset(MODEL_SCENES.get(self.model, ())) if self.profile.supports_scenes else frozenset()
 
     @property
     def active_mode(self) -> str:
@@ -154,7 +154,7 @@ class _ActiveModeMixin(_CoordinatorBase):
             return "off"
         if self.diy_code is not None:
             return "custom"
-        if self.effect is not None:
+        if self.effect is not None or (self.color_mode is ParsedMode.SCENE and self._scene_code is not None):
             return "scene"
         if self.music_mode not in (None, "off"):
             return "music"
@@ -166,6 +166,7 @@ class _ActiveModeMixin(_CoordinatorBase):
         self,
         scene_name: str,
         *,
+        scene_entry: SceneEntry | None = None,
         speed_index: int | None = None,
         canonical_body: bytes | None = None,
         writer: Callable[[bytes], Awaitable[None]] | None = None,
@@ -177,6 +178,7 @@ class _ActiveModeMixin(_CoordinatorBase):
         async with async_control_intent(self, intent):
             await self._async_apply_native_scene_locked(
                 scene_name,
+                scene_entry=scene_entry,
                 speed_index=speed_index,
                 canonical_body=canonical_body,
                 writer=writer,
@@ -190,6 +192,7 @@ class _ActiveModeMixin(_CoordinatorBase):
         self,
         scene_name: str,
         *,
+        scene_entry: SceneEntry | None = None,
         speed_index: int | None = None,
         canonical_body: bytes | None = None,
         writer: Callable[[bytes], Awaitable[None]] | None = None,
@@ -198,7 +201,13 @@ class _ActiveModeMixin(_CoordinatorBase):
         verify: bool,
         intent: ControlIntent,
     ) -> None:
-        scene = MODEL_SCENES[self.model].get(scene_name)
+        if not self.profile.supports_scenes:
+            raise ValueError(f"{self.model} does not support native scenes")
+        if scene_entry is None:
+            scene_name = canonical_scene_key(self.model, scene_name)
+            scene = MODEL_SCENES[self.model].get(scene_name)
+        else:
+            scene = scene_entry
         if scene is None:
             raise ValueError(f"unknown native scene {scene_name!r}")
         packets = build_native_scene_packets(
@@ -240,11 +249,13 @@ class _ActiveModeMixin(_CoordinatorBase):
         await apply()
         if power_in_sequence:
             self.is_on = True
-        if verify and self.profile.state_readable and not await self.refresh_state(expected_effect=scene_name):
+        if verify and self.profile.state_readable and not await self.refresh_state(expected_scene_code=scene.code):
             await apply()
-            if not await self.refresh_state(expected_effect=scene_name):
+            if not await self.refresh_state(expected_scene_code=scene.code):
                 raise RuntimeError(f"Failed to confirm scene {scene_name!r}")
+        self.color_mode = ParsedMode.SCENE
         self.effect = scene_name
+        self._scene_code = scene.code
         self.diy_code = None
         self.music_mode = self.video_mode = "off"
         self.async_set_updated_data(self.data or {})

--- a/custom_components/ha_govee_led_ble/coordinator_status.py
+++ b/custom_components/ha_govee_led_ble/coordinator_status.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, cast
 
-from .const import MUSIC_MODE_SLUGS
+from .const import MUSIC_MODE_SLUGS, ReadDomain
 from .generated_protocol_adapter import ProtocolParseResult, parse_status_result
 from .scenes import MODEL_SCENES
 
@@ -15,18 +15,7 @@ _SCENE_EFFECT_BY_MODEL_ID = {
 _RHYTHM_MODE_ID = MUSIC_MODE_SLUGS["rhythm"]
 
 
-class StatusDomain(Enum):
-    POWER = auto()
-    BRIGHTNESS = auto()
-    COLOUR_MODE = auto()
-    FIRMWARE = auto()
-    HARDWARE = auto()
-    SUBORDINATE_20 = auto()
-    SUBORDINATE_21 = auto()
-    DISPLAY_SETTING = auto()
-    RELATIVE_BRIGHTNESS = auto()
-    SEGMENTS = auto()
-    OTHER = auto()
+StatusDomain = ReadDomain
 
 
 _STATUS_DOMAIN_NAMES = {
@@ -145,7 +134,7 @@ def parse_color_mode(generated: Any, model: str) -> ParsedColorModeResponse:
             scene_code = int(body.detail.scene_id)
             return ParsedColorModeResponse(
                 mode=ParsedMode.SCENE,
-                effect=_SCENE_EFFECT_BY_MODEL_ID["H6199"].get(scene_code),
+                effect=_SCENE_EFFECT_BY_MODEL_ID.get(model, {}).get(scene_code),
                 scene_code=scene_code,
             )
         if mode_name == "static_colour":
@@ -156,7 +145,7 @@ def parse_color_mode(generated: Any, model: str) -> ParsedColorModeResponse:
         scene_code = int(body.mode_body.scene_id)
         return ParsedColorModeResponse(
             mode=ParsedMode.SCENE,
-            effect=_SCENE_EFFECT_BY_MODEL_ID["H617A"].get(scene_code),
+            effect=_SCENE_EFFECT_BY_MODEL_ID.get(model, {}).get(scene_code),
             scene_code=scene_code,
         )
     if mode_name == "diy":

--- a/custom_components/ha_govee_led_ble/diagnostics.py
+++ b/custom_components/ha_govee_led_ble/diagnostics.py
@@ -48,7 +48,12 @@ async def async_get_config_entry_diagnostics(
         "effect_categories": sorted(coordinator.effect_categories),
         "prefix_effect_names": coordinator.prefix_effect_names,
         "always_include_custom_effects": coordinator.always_include_custom_effects,
+        "support_quality": coordinator.profile.support_quality.value,
         "state_readable": coordinator.profile.state_readable,
+        "read_domains": sorted(domain.value for domain in coordinator.profile.read_domains),
+        "setup_required_read_domains": sorted(
+            domain.value for domain in coordinator.profile.setup_required_read_domains
+        ),
         "supports_rgb": coordinator.profile.supports_rgb,
         "supports_color_temperature": coordinator.profile.supports_color_temperature,
         "color_temperature_range": {

--- a/custom_components/ha_govee_led_ble/effect_catalogue.py
+++ b/custom_components/ha_govee_led_ble/effect_catalogue.py
@@ -15,7 +15,6 @@ from .effect_contracts import (
     workflow_capability_state,
 )
 from .effect_domain import (
-    H617A_SEGMENT_COUNT,
     MAX_MULTI_EFFECTS,
     MAX_PALETTE_COLOURS,
     EffectContent,
@@ -508,6 +507,7 @@ def _single_template(model: str, family: DiyEffectFamily) -> CatalogueTemplate:
 
 
 def _music_template(model: str, mode: NativeModeOption) -> CatalogueTemplate:
+    profile = MODEL_PROFILES[model]
     return CatalogueTemplate(
         id=f"template:music:{mode.id}",
         label=mode.label,
@@ -515,7 +515,7 @@ def _music_template(model: str, mode: NativeModeOption) -> CatalogueTemplate:
         content=MusicProfile(
             model=model,
             mode=mode.id,
-            sensitivity=100 if model == "H6199" else 99,
+            sensitivity=profile.music_sensitivity_max,
             colour=None,
             calm=False if mode.id in {"rhythm", "bloom", "shiny"} else None,
             parameters={},
@@ -523,63 +523,54 @@ def _music_template(model: str, mode: NativeModeOption) -> CatalogueTemplate:
     )
 
 
-def _video_template(mode: NativeModeOption) -> CatalogueTemplate:
+def _video_template(model: str, mode: NativeModeOption) -> CatalogueTemplate:
     return CatalogueTemplate(
         id=f"template:video:{mode.id}",
         label=mode.label,
         category="video",
         content=VideoProfile(
-            model="H6199",
+            model=model,
             mode=mode.id,
             full_screen=True,
             saturation=50,
             sound_effects=False,
             sound_effects_softness=50,
-            white_balance_position=17,
+            white_balance_position=MODEL_PROFILES[model].video_white_balance_default,
             relative_brightness=RelativeBrightness(100, 100, 100, 100),
             blank_screen=False,
         ),
     )
 
 
-H617A_CATALOGUE_TEMPLATES: Final = (
-    CatalogueTemplate(
-        id="template:paint",
-        label="Paint",
-        category="single-layer",
-        content=PaintedEffect(
-            effect="clockwise",
-            speed=50,
-            brightness=100,
-            segments=(None,) * H617A_SEGMENT_COUNT,
+def _h617a_catalogue_templates(
+    model: str,
+    music_modes: tuple[NativeModeOption, ...],
+) -> tuple[CatalogueTemplate, ...]:
+    return (
+        CatalogueTemplate(
+            id="template:paint",
+            label="Paint",
+            category="single-layer",
+            content=PaintedEffect(
+                effect="clockwise",
+                speed=50,
+                brightness=100,
+                segments=(None,) * MODEL_PROFILES[model].segment_count,
+            ),
         ),
-    ),
-    *(_single_template("H617A", family) for family in H617A_TYPE04_FAMILIES),
-    *(_music_template("H617A", mode) for mode in H617A_NATIVE_MUSIC_MODES),
-)
+        *(_single_template(model, family) for family in H617A_TYPE04_FAMILIES),
+        *(_music_template(model, mode) for mode in music_modes),
+    )
 
+
+H617A_CATALOGUE_TEMPLATES: Final = _h617a_catalogue_templates("H617A", H617A_NATIVE_MUSIC_MODES)
 H617E_NATIVE_MUSIC_MODES: Final = _native_music_modes("H617E")
-
-H617E_CATALOGUE_TEMPLATES: Final = (
-    CatalogueTemplate(
-        id="template:paint",
-        label="Paint",
-        category="single-layer",
-        content=PaintedEffect(
-            effect="clockwise",
-            speed=50,
-            brightness=100,
-            segments=(None,) * H617A_SEGMENT_COUNT,
-        ),
-    ),
-    *(_single_template("H617E", family) for family in H617A_TYPE04_FAMILIES),
-    *(_music_template("H617E", mode) for mode in H617E_NATIVE_MUSIC_MODES),
-)
+H617E_CATALOGUE_TEMPLATES: Final = _h617a_catalogue_templates("H617E", H617E_NATIVE_MUSIC_MODES)
 
 H6199_CATALOGUE_TEMPLATES: Final = (
     *(_single_template("H6199", family) for family in H6199_PALETTE_DIY_FAMILIES),
     *(_music_template("H6199", mode) for mode in H6199_NATIVE_MUSIC_MODES),
-    *(_video_template(mode) for mode in H6199_VIDEO_MODES),
+    *(_video_template("H6199", mode) for mode in H6199_VIDEO_MODES),
 )
 
 WORKSHOP_PROTOCOL_FIXTURES: Final = (

--- a/custom_components/ha_govee_led_ble/effect_compiler.py
+++ b/custom_components/ha_govee_led_ble/effect_compiler.py
@@ -7,9 +7,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from hashlib import sha256
-from typing import Any, Final, assert_never
+from typing import Any, assert_never
 
-from .const import MODEL_PROFILES, MUSIC_MODE_SLUGS, protocol_model
+from .const import MODEL_PROFILES, MUSIC_MODE_SLUGS, get_profile, protocol_model
 from .coordinator_modes import (
     MUSIC_STYLE_SLUGS,
     music_mode_has_parameter_write,
@@ -59,7 +59,7 @@ from .layered_scene import CatalogueRef
 from .layered_scene_decoder import encode_layered_scene, encode_workshop_effect
 from .native_scenes import apply_scene_speed, build_native_scene_packets
 from .palette_scene_decoder import encode_palette_scene
-from .scenes import MODEL_SCENES, SceneEntry
+from .scenes import MODEL_SCENES, SceneEntry, resolve_scene_identity
 from .transport import fragment_a3
 
 
@@ -147,12 +147,6 @@ class CompiledVideoProfile:
 CompiledApplication = CompiledEffect | CompiledMusicProfile | CompiledVideoProfile
 
 
-_ADVANCED_CARRIER_IDENTITIES: Final = {
-    "H617A": (1013, 11836),
-    "H6199": (29884, 41599),
-}
-
-
 def compatibility(item: LibraryItem, model: str) -> CompatibilityResult:
     content = item.content
     if isinstance(content, OpaqueContent):
@@ -188,6 +182,11 @@ def compatibility(item: LibraryItem, model: str) -> CompatibilityResult:
             )
         return CompatibilityResult(CompatibilityState.COMPATIBLE)
     if isinstance(content, BuiltinScene):
+        if not get_profile(model).supports_scenes:
+            return CompatibilityResult(
+                CompatibilityState.INCOMPATIBLE,
+                (f"{model} native scenes are not supported",),
+            )
         if content.template.sku != model:
             return CompatibilityResult(
                 CompatibilityState.INCOMPATIBLE,
@@ -229,6 +228,11 @@ def compatibility(item: LibraryItem, model: str) -> CompatibilityResult:
             (f"this H617A custom-effect definition is not supported on {model}",),
         )
     if isinstance(content, PaletteScene | LayeredScene):
+        if not get_profile(model).supports_scenes:
+            return CompatibilityResult(
+                CompatibilityState.INCOMPATIBLE,
+                (f"{model} authored scenes are not supported",),
+            )
         if content.template.sku != model:
             return CompatibilityResult(
                 CompatibilityState.INCOMPATIBLE,
@@ -246,12 +250,11 @@ def compatibility(item: LibraryItem, model: str) -> CompatibilityResult:
             return CompatibilityResult(CompatibilityState.INCOMPATIBLE, (str(error),))
         return CompatibilityResult(CompatibilityState.COMPATIBLE)
     if isinstance(content, LayeredEffect):
-        if protocol_model(model) in _ADVANCED_CARRIER_IDENTITIES:
-            return CompatibilityResult(CompatibilityState.COMPATIBLE)
-        return CompatibilityResult(
-            CompatibilityState.INCOMPATIBLE,
-            (f"{model} layered-scene framing is not supported",),
-        )
+        try:
+            _advanced_carrier(model)
+        except ValueError as error:
+            return CompatibilityResult(CompatibilityState.INCOMPATIBLE, (str(error),))
+        return CompatibilityResult(CompatibilityState.COMPATIBLE)
     assert_never(content)
 
 
@@ -506,25 +509,25 @@ def _resolve_scene(
 ) -> tuple[str, SceneEntry]:
     if template.catalogue_schema_version != 1:
         raise ValueError(f"catalogue schema version {template.catalogue_schema_version} is not supported")
-    scenes = MODEL_SCENES.get(model)
-    if scenes is None:
+    if model not in MODEL_SCENES:
         raise ValueError(f"{model} has no scene catalogue")
-    for key, entry in scenes.items():
-        if entry.scene_id == template.scene_id and entry.effect_id == template.effect_id:
-            if expected_scene_type is not None and entry.scene_type != expected_scene_type:
-                raise ValueError(
-                    f"{model} scene identity ({template.scene_id}, {template.effect_id}) "
-                    f"uses type {entry.scene_type}, not type {expected_scene_type}"
-                )
-            return key, entry
-    raise ValueError(f"{model} scene identity ({template.scene_id}, {template.effect_id}) was not found")
+    resolved = resolve_scene_identity(model, template.scene_id, template.effect_id)
+    if resolved is None:
+        raise ValueError(f"{model} scene identity ({template.scene_id}, {template.effect_id}) was not found")
+    key, entry = resolved
+    if expected_scene_type is not None and entry.scene_type != expected_scene_type:
+        raise ValueError(
+            f"{model} scene identity ({template.scene_id}, {template.effect_id}) "
+            f"uses type {entry.scene_type}, not type {expected_scene_type}"
+        )
+    return key, entry
 
 
 def _advanced_carrier(model: str) -> tuple[str, SceneEntry]:
-    try:
-        scene_id, effect_id = _ADVANCED_CARRIER_IDENTITIES[protocol_model(model) or model]
-    except KeyError as error:
-        raise ValueError(f"{model} layered-scene framing is not supported") from error
+    identity = get_profile(model).advanced_scene_carrier
+    if identity is None:
+        raise ValueError(f"{model} layered-scene framing is not supported")
+    scene_id, effect_id = identity
     return _resolve_scene(
         model,
         CatalogueRef(model, scene_id, effect_id),

--- a/custom_components/ha_govee_led_ble/effect_contracts.py
+++ b/custom_components/ha_govee_led_ble/effect_contracts.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from typing import Final
 
-from .const import default_effect_categories
+from .const import default_effect_categories, get_profile
 from .effect_domain import EFFECT_SCHEMA_VERSION, JsonValue
 from .effect_limits import (
     MAX_DEPLOYMENT_RECORDS,
@@ -164,7 +164,7 @@ def _capability(
     )
 
 
-RELEASE_CAPABILITY_CONTRACT: Final = (
+_RELEASE_CAPABILITY_BASE: Final = (
     _capability(
         "H617A",
         CapabilityWorkflow.NATIVE_SCENES,
@@ -355,21 +355,23 @@ RELEASE_CAPABILITY_CONTRACT: Final = (
 )
 
 
-_CAPABILITY_MODEL_ALIASES: Final = {"H617E": "H617A"}
+RELEASE_CAPABILITY_CONTRACT: Final = (
+    *(capability for capability in _RELEASE_CAPABILITY_BASE if capability.model == "H617A"),
+    *(replace(capability, model="H617E") for capability in _RELEASE_CAPABILITY_BASE if capability.model == "H617A"),
+    *(capability for capability in _RELEASE_CAPABILITY_BASE if capability.model == "H6199"),
+)
 
 
 def release_capabilities_for_model(model: str) -> tuple[ReleaseCapability, ...]:
-    contract_model = _CAPABILITY_MODEL_ALIASES.get(model, model)
-    return tuple(capability for capability in RELEASE_CAPABILITY_CONTRACT if capability.model == contract_model)
+    return tuple(capability for capability in RELEASE_CAPABILITY_CONTRACT if capability.model == model)
 
 
 def release_capability(model: str, workflow: CapabilityWorkflow) -> ReleaseCapability | None:
-    contract_model = _CAPABILITY_MODEL_ALIASES.get(model, model)
     return next(
         (
             capability
             for capability in RELEASE_CAPABILITY_CONTRACT
-            if capability.model == contract_model and capability.workflow is workflow
+            if capability.model == model and capability.workflow is workflow
         ),
         None,
     )
@@ -501,12 +503,6 @@ def device_effect_capabilities(
         music=studio_apply_capability_state(model, CapabilityWorkflow.NATIVE_MUSIC),
         video=studio_apply_capability_state(model, CapabilityWorkflow.VIDEO),
         workshop=studio_apply_capability_state(model, CapabilityWorkflow.WORKSHOP),
-        readback=(
-            "diy_code_only"
-            if model in {"H617A", "H617E"}
-            else "scene_selector_for_user_effects"
-            if release_capabilities_for_model(model)
-            else "none"
-        ),
+        readback=get_profile(model).effect_readback,
         effect_categories=(default_effect_categories(model) if effect_categories is None else effect_categories),
     )

--- a/custom_components/ha_govee_led_ble/effect_deployments.py
+++ b/custom_components/ha_govee_led_ble/effect_deployments.py
@@ -87,6 +87,7 @@ class PriorControlState:
     rgb_color: tuple[int, int, int]
     color_temp_kelvin: int | None = None
     effect: str | None = None
+    scene_code: int | None = None
     diy_code: int | None = None
     music_mode: str = "off"
     video_mode: str = "off"
@@ -151,10 +152,9 @@ class PriorControlState:
                     maximum=MAX_IDENTIFIER_LENGTH,
                     error_type=EffectStorageError,
                 )
-        if self.diy_code is not None and (
-            not isinstance(self.diy_code, int) or isinstance(self.diy_code, bool) or not 0 <= self.diy_code <= 0xFFFF
-        ):
-            raise EffectStorageError("prior DIY code must be from 0 to 65535")
+        for code, name in ((self.scene_code, "scene"), (self.diy_code, "DIY")):
+            if code is not None and (not isinstance(code, int) or isinstance(code, bool) or not 0 <= code <= 0xFFFF):
+                raise EffectStorageError(f"prior {name} code must be from 0 to 65535")
         if (
             not isinstance(self.music_sensitivity, int)
             or isinstance(self.music_sensitivity, bool)
@@ -232,6 +232,7 @@ class PriorControlState:
             "rgb_color": list(self.rgb_color),
             "color_temp_kelvin": self.color_temp_kelvin,
             "effect": self.effect,
+            "scene_code": self.scene_code,
             "diy_code": self.diy_code,
             "music_mode": self.music_mode,
             "video_mode": self.video_mode,
@@ -272,6 +273,7 @@ class PriorControlState:
             rgb_color=_required_rgb(raw, "rgb_color"),
             color_temp_kelvin=_optional_int(raw, "color_temp_kelvin"),
             effect=_optional_str(raw, "effect"),
+            scene_code=_optional_int(raw, "scene_code"),
             diy_code=_optional_int(raw, "diy_code"),
             music_mode=_optional_str(raw, "music_mode") or "off",
             video_mode=_optional_str(raw, "video_mode") or "off",
@@ -637,6 +639,20 @@ class EffectDeploymentRepository:
             if record.config_entry_id == config_entry_id
             and record.target_mode == "scene"
             and record.target_effect == effect
+        )
+        return max(matching, key=lambda record: record.updated_at, default=None)
+
+    def latest_for_scene_code(
+        self,
+        config_entry_id: str,
+        scene_code: int,
+    ) -> DeploymentRecord | None:
+        matching = tuple(
+            record
+            for record in self.snapshot().records
+            if record.config_entry_id == config_entry_id
+            and record.target_mode == "scene"
+            and record.diy_code == scene_code
         )
         return max(matching, key=lambda record: record.updated_at, default=None)
 

--- a/custom_components/ha_govee_led_ble/effect_preview.py
+++ b/custom_components/ha_govee_led_ble/effect_preview.py
@@ -19,6 +19,7 @@ from homeassistant.core import Event, HomeAssistant
 
 from .const import DOMAIN, protocol_model
 from .control_arbiter import ControlIntent, PreviewAdmission, async_control_intent
+from .coordinator_status import ParsedMode
 from .effect_active_workspace import ActiveEffectWorkspace, ActiveEffectWorkspaceRepository
 from .effect_catalogue import (
     H6199_PALETTE_DIY_APPLY_CODE,
@@ -58,12 +59,20 @@ from .effect_runtime import (
     observable_signature_for_state,
     resolve_diy_code,
 )
-from .effect_scene_defaults import NativeSceneDefault, NativeSceneDefaultRepository
-from .effect_scenes import ResolvedScene, resolve_scene, resolve_scene_application_body
+from .effect_scene_defaults import NativeSceneDefaultRepository
+from .effect_scenes import (
+    ResolvedScene,
+    async_delete_scene_defaults,
+    async_store_scene_default,
+    resolve_scene,
+    resolve_scene_application_body,
+    scene_default_for,
+)
 from .effect_template_defaults import CatalogueTemplateDefault, CatalogueTemplateDefaultRepository
 from .generated_protocol_adapter import build_power
 from .h6199_calibration import WHITE_BALANCE_POSITIONS
 from .native_scenes import encode_authored_scene_body, resolve_native_scene_body
+from .scenes import canonical_scene_key, scene_code_is_ambiguous
 
 PREVIEW_VERIFY_DELAY = 0.75
 PREVIEW_VERIFY_TIMEOUT = 4.0
@@ -499,10 +508,12 @@ class EffectPreviewManager:
         self.ensure_session(session_id, owner)
         coordinator = self._loaded_coordinator(config_entry_id)
         resolved = resolve_scene(coordinator.model, scene_id, effect_id)
-        scene_default = self._scene_defaults.get(
+        scene_default = scene_default_for(
+            self._scene_defaults,
             config_entry_id,
-            scene_id,
-            effect_id,
+            coordinator.model,
+            resolved.key,
+            resolved.entry,
         )
         try:
             canonical_body, resolved_speed = resolve_scene_application_body(
@@ -893,6 +904,7 @@ class EffectPreviewManager:
             if request.scene is not None:
                 await coordinator.async_apply_native_scene(
                     request.scene.key,
+                    scene_entry=request.scene.entry,
                     speed_index=request.speed_index,
                     canonical_body=request.canonical_body,
                     before_write=writer.begin,
@@ -1009,11 +1021,17 @@ class EffectPreviewManager:
             return
 
         if request.item is not None and self._active_workspaces is not None:
-            signature = observable_signature_for_state(
-                coordinator,
-                mode=_active_mode_for_workspace(coordinator),
-                diy_code=coordinator.diy_code,
-                effect=coordinator.effect,
+            signature = (
+                f"scene-code:{compiled.diy_code}"
+                if isinstance(compiled, CompiledEffect)
+                and compiled.activation_mode is ActivationMode.SCENE
+                and compiled.diy_code is not None
+                else observable_signature_for_state(
+                    coordinator,
+                    mode=_active_mode_for_workspace(coordinator),
+                    diy_code=coordinator.diy_code,
+                    effect=coordinator.effect,
+                )
             )
             if signature is not None:
                 self._active_workspaces.set(
@@ -1163,21 +1181,21 @@ class EffectPreviewManager:
             )
         catalogue_body, catalogue_speed = resolve_native_scene_body(scene.entry)
         if canonical_body == catalogue_body and speed_index == catalogue_speed:
-            await self._scene_defaults.async_delete(
+            await async_delete_scene_defaults(
+                self._scene_defaults,
                 request.config_entry_id,
-                scene.entry.scene_id,
-                scene.entry.effect_id,
+                self._loaded_coordinator(request.config_entry_id).model,
+                scene,
             )
             return
-        await self._scene_defaults.async_set(
-            NativeSceneDefault(
-                config_entry_id=request.config_entry_id,
-                scene_id=scene.entry.scene_id,
-                effect_id=scene.entry.effect_id,
-                updated_at=request.updated_at,
-                canonical_body=canonical_body,
-                speed_index=speed_index,
-            )
+        await async_store_scene_default(
+            self._scene_defaults,
+            request.config_entry_id,
+            self._loaded_coordinator(request.config_entry_id).model,
+            scene,
+            updated_at=request.updated_at,
+            canonical_body=canonical_body,
+            speed_index=speed_index,
         )
 
     async def _async_begin_transmission(self, request: _PreviewRequest) -> None:
@@ -1657,7 +1675,9 @@ def _install_effect_state(coordinator: Any, compiled: CompiledEffect) -> None:
     if compiled.activation_packet is None:
         return
     if compiled.activation_mode is ActivationMode.SCENE:
+        coordinator.color_mode = ParsedMode.SCENE
         coordinator.effect = compiled.expected_effect
+        coordinator._scene_code = compiled.diy_code
         coordinator.diy_code = None
     else:
         coordinator.effect = None
@@ -1673,10 +1693,26 @@ def _verification_expectations(
     if not coordinator.profile.state_readable:
         return None
     if request.scene is not None:
-        return {"is_on": True, "effect": request.scene.key}
+        scene_expectations: dict[str, Any] = {
+            "is_on": True,
+            "scene_code": request.scene.entry.code,
+        }
+        if scene_code_is_ambiguous(coordinator.model, request.scene.entry.code):
+            scene_expectations["effect"] = canonical_scene_key(coordinator.model, request.scene.key)
+        return scene_expectations
     if isinstance(compiled, CompiledEffect):
         if compiled.activation_mode is ActivationMode.SCENE:
-            return {"is_on": True, "effect": compiled.expected_effect}
+            compiled_expectations: dict[str, Any] = {
+                "is_on": True,
+                "scene_code": compiled.diy_code,
+            }
+            if (
+                compiled.diy_code is not None
+                and compiled.expected_effect is not None
+                and scene_code_is_ambiguous(compiled.model, compiled.diy_code)
+            ):
+                compiled_expectations["effect"] = canonical_scene_key(compiled.model, compiled.expected_effect)
+            return compiled_expectations
         if compiled.content_kind == "workshop":
             return {"is_on": True, "unknown_scene_code": compiled.diy_code}
         if protocol_model(compiled.model) == "H617A":

--- a/custom_components/ha_govee_led_ble/effect_runtime.py
+++ b/custom_components/ha_govee_led_ble/effect_runtime.py
@@ -61,6 +61,7 @@ from .native_profile_controls import (
     apply_relative_brightness,
     apply_white_balance,
 )
+from .scenes import canonical_scene_key, scene_code_is_ambiguous
 
 ACTIVATION_ATTEMPTS = 2
 VERIFICATION_ATTEMPTS = 2
@@ -381,7 +382,10 @@ class EffectDeploymentEngine:
                         observed_at=record.updated_at,
                         refreshed=refreshed,
                     )
-                    prior_state = self._capture_prior_state(coordinator)
+                    prior_state = self._capture_prior_state(
+                        coordinator,
+                        config_entry_id=current.config_entry_id,
+                    )
                     next_record = replace(current, prior_state=prior_state)
                     await self._deployments.async_put(next_record, expected_version=None)
                     current = next_record
@@ -776,12 +780,23 @@ class EffectDeploymentEngine:
     def _capture_prior_state(
         self,
         coordinator: GoveeBLECoordinator,
+        *,
+        config_entry_id: str,
     ) -> PriorControlState:
         capture = getattr(coordinator, "capture_effect_control_state", None)
         if capture is not None:
             captured = capture()
             if not isinstance(captured, PriorControlState):
                 raise TypeError("coordinator returned an invalid prior control state")
+            observed = self._device_cache.get(config_entry_id) if self._device_cache is not None else None
+            if captured.scene_code is not None and observed is not None and observed.matched_operation_id is not None:
+                matched = self._deployments.get_optional(observed.matched_operation_id)
+                if (
+                    matched is not None
+                    and matched.target_mode == ActivationMode.SCENE.value
+                    and matched.diy_code == captured.scene_code
+                ):
+                    captured = replace(captured, effect=matched.target_effect)
             return captured
         return PriorControlState(
             mode=_coordinator_mode(coordinator),
@@ -790,6 +805,7 @@ class EffectDeploymentEngine:
             rgb_color=getattr(coordinator, "rgb_color", (255, 255, 255)),
             color_temp_kelvin=getattr(coordinator, "color_temp_kelvin", None),
             effect=getattr(coordinator, "effect", None),
+            scene_code=getattr(coordinator, "scene_code", None),
             diy_code=coordinator.diy_code,
             music_mode=getattr(coordinator, "music_mode", "off"),
             video_mode=getattr(coordinator, "video_mode", "off"),
@@ -840,20 +856,50 @@ class EffectDeploymentEngine:
     ) -> ObservedDeviceState:
         mode = _coordinator_mode(coordinator)
         previous = self._device_cache.get(config_entry_id) if self._device_cache is not None else None
+        scene_code = getattr(coordinator, "scene_code", None)
         raw_scene_code = getattr(coordinator, "unknown_scene_code", None)
         diy_code = coordinator.diy_code if mode == "custom" else None
         effect = coordinator.effect if mode == "scene" else None
         observable_signature = observable_signature_for_coordinator(coordinator)
+        observable_signatures = observable_signatures_for_coordinator(coordinator)
         workspace = self._active_workspaces.get(config_entry_id) if self._active_workspaces is not None else None
         workspace_matches = (
             workspace is not None
             and workspace.model == coordinator.model
-            and workspace.observable_signature == observable_signature
+            and workspace.observable_signature in observable_signatures
         )
         if workspace_matches and raw_scene_code is not None:
             mode = "custom"
             diy_code = raw_scene_code
             effect = None
+        if scene_code is not None and matched_record is None:
+            latest_scene = self._deployments.latest_for_scene_code(config_entry_id, scene_code)
+            if (
+                latest_scene is not None
+                and latest_scene.phase is DeploymentPhase.CONFIRMED
+                and _scene_record_matches(coordinator, latest_scene, scene_code)
+            ):
+                matched_record = latest_scene
+        if matched_record is not None and matched_record.target_mode == ActivationMode.SCENE.value:
+            observable_signature = f"scene-code:{scene_code}" if scene_code is not None else observable_signature
+            if (
+                workspace is not None
+                and workspace.model == coordinator.model
+                and matched_record.target_effect is not None
+                and workspace.observable_signature
+                in {
+                    observable_signature,
+                    f"scene:{matched_record.target_effect}",
+                }
+            ):
+                workspace_matches = True
+                if (
+                    self._active_workspaces is not None
+                    and observable_signature is not None
+                    and workspace.observable_signature != observable_signature
+                ):
+                    workspace = replace(workspace, observable_signature=observable_signature)
+                    self._active_workspaces.set(workspace)
         if raw_scene_code is not None:
             if matched_record is None and not workspace_matches:
                 latest = self._deployments.latest_for_diy_code(config_entry_id, raw_scene_code)
@@ -866,7 +912,7 @@ class EffectDeploymentEngine:
             latest = self._deployments.latest_for_diy_code(config_entry_id, diy_code)
             if latest is not None and latest.phase is DeploymentPhase.CONFIRMED:
                 matched_record = latest
-        if effect is not None and matched_record is None and not workspace_matches:
+        if scene_code is None and effect is not None and matched_record is None and not workspace_matches:
             latest = self._deployments.latest_for_effect(config_entry_id, effect)
             if latest is not None and latest.phase is DeploymentPhase.CONFIRMED:
                 matched_record = latest
@@ -883,7 +929,7 @@ class EffectDeploymentEngine:
             confidence = workspace.confidence
         elif profile_match and matched_record is not None:
             confidence = matched_record.verification_confidence
-        elif diy_code is not None or effect is not None:
+        elif diy_code is not None or effect is not None or scene_code is not None:
             confidence = (
                 ObservationConfidence.ACTIVATION_MATCH if matched_record is not None else ObservationConfidence.UNKNOWN
             )
@@ -998,6 +1044,9 @@ def _active_workspace_content(
 def observable_signature_for_coordinator(
     coordinator: GoveeBLECoordinator,
 ) -> str | None:
+    scene_code = getattr(coordinator, "scene_code", None)
+    if scene_code is not None and coordinator.effect is not None:
+        return f"scene-code:{scene_code}"
     unknown_scene_code = coordinator.unknown_scene_code
     if unknown_scene_code is not None:
         return f"custom:{unknown_scene_code}"
@@ -1007,6 +1056,21 @@ def observable_signature_for_coordinator(
         diy_code=coordinator.diy_code,
         effect=coordinator.effect,
     )
+
+
+def observable_signatures_for_coordinator(
+    coordinator: GoveeBLECoordinator,
+) -> frozenset[str]:
+    signatures = {
+        signature
+        for signature in (
+            observable_signature_for_coordinator(coordinator),
+            (f"scene-code:{coordinator.scene_code}" if getattr(coordinator, "scene_code", None) is not None else None),
+            f"scene:{coordinator.effect}" if coordinator.effect is not None else None,
+        )
+        if signature is not None
+    }
+    return frozenset(signatures)
 
 
 def _coordinator_mode(coordinator: GoveeBLECoordinator) -> str:
@@ -1099,5 +1163,24 @@ def _activation_matches(
     if not coordinator.is_on:
         return False
     if record.target_mode == ActivationMode.SCENE.value:
+        scene_code = getattr(coordinator, "scene_code", None)
+        if scene_code is not None:
+            return _scene_record_matches(coordinator, record, scene_code)
         return record.target_effect is not None and coordinator.effect == record.target_effect
     return coordinator.diy_code == record.diy_code or coordinator.unknown_scene_code == record.diy_code
+
+
+def _scene_record_matches(
+    coordinator: GoveeBLECoordinator,
+    record: DeploymentRecord,
+    scene_code: int,
+) -> bool:
+    if record.diy_code != scene_code:
+        return False
+    if not scene_code_is_ambiguous(coordinator.model, scene_code):
+        return True
+    return (
+        record.target_effect is not None
+        and coordinator.effect is not None
+        and canonical_scene_key(coordinator.model, record.target_effect) == coordinator.effect
+    )

--- a/custom_components/ha_govee_led_ble/effect_scene_defaults.py
+++ b/custom_components/ha_govee_led_ble/effect_scene_defaults.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from hashlib import sha256
 from typing import Any, Final, cast
@@ -115,24 +115,51 @@ class NativeSceneDefaultRepository:
         return None if not isinstance(raw, Mapping) else NativeSceneDefault.from_dict(raw)
 
     async def async_set(self, value: NativeSceneDefault) -> None:
+        await self.async_replace_identities(
+            value.config_entry_id,
+            ((value.scene_id, value.effect_id),),
+            value,
+        )
+
+    async def async_delete(self, config_entry_id: str, scene_id: int, effect_id: int) -> None:
+        await self.async_replace_identities(
+            config_entry_id,
+            ((scene_id, effect_id),),
+            None,
+        )
+
+    async def async_replace_identities(
+        self,
+        config_entry_id: str,
+        identities: Iterable[tuple[int, int]],
+        value: NativeSceneDefault | None,
+    ) -> None:
+        if value is not None and value.config_entry_id != config_entry_id:
+            raise EffectStorageError("scene-default replacement has mismatched config entry")
         async with self._lock:
             candidate = copy.deepcopy(self._require_loaded())
             devices = candidate["devices"]
-            if value.config_entry_id not in devices and len(devices) >= MAX_DEVICE_CACHE_ENTRIES:
+            if value is not None and config_entry_id not in devices and len(devices) >= MAX_DEVICE_CACHE_ENTRIES:
                 raise EffectLimitError(f"scene-default store must not exceed {MAX_DEVICE_CACHE_ENTRIES} devices")
-            devices.setdefault(value.config_entry_id, {})[_scene_key(value.scene_id, value.effect_id)] = value.to_dict()
-            _validate_store(candidate)
-            await self._store.async_save(candidate)
-            self._data = candidate
-
-    async def async_delete(self, config_entry_id: str, scene_id: int, effect_id: int) -> None:
-        async with self._lock:
-            candidate = copy.deepcopy(self._require_loaded())
-            records = candidate["devices"].get(config_entry_id)
-            if not isinstance(records, dict) or records.pop(_scene_key(scene_id, effect_id), None) is None:
+            records = devices.get(config_entry_id)
+            if not isinstance(records, dict):
+                records = {}
+            changed = False
+            for scene_id, effect_id in identities:
+                changed = records.pop(_scene_key(scene_id, effect_id), None) is not None or changed
+            if value is not None:
+                raw = value.to_dict()
+                key = _scene_key(value.scene_id, value.effect_id)
+                changed = records.get(key) != raw or changed
+                records[key] = raw
+                devices[config_entry_id] = records
+            elif records:
+                devices[config_entry_id] = records
+            else:
+                changed = devices.pop(config_entry_id, None) is not None or changed
+            if not changed:
                 return
-            if not records:
-                candidate["devices"].pop(config_entry_id)
+            _validate_store(candidate)
             await self._store.async_save(candidate)
             self._data = candidate
 

--- a/custom_components/ha_govee_led_ble/effect_scenes.py
+++ b/custom_components/ha_govee_led_ble/effect_scenes.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
+from .const import get_profile
 from .effect_domain import (
     BuiltinScene,
     CatalogueRef,
@@ -28,8 +29,12 @@ from .palette_scene_decoder import decode_palette_scene
 from .scenes import (
     MODEL_SCENE_LABELS,
     MODEL_SCENES,
+    OFFICIAL_MODEL_SCENES,
     SCENE_ENTRIES,
     SceneEntry,
+    canonical_scene_key,
+    legacy_scene_entries,
+    resolve_scene_identity,
 )
 
 CATALOGUE_SCHEMA_VERSION = 1
@@ -40,6 +45,92 @@ class ResolvedScene:
     key: str
     label: str
     entry: SceneEntry
+
+
+def scene_default_for(
+    repository: NativeSceneDefaultRepository,
+    config_entry_id: str,
+    model: str,
+    scene_key: str,
+    entry: SceneEntry,
+) -> NativeSceneDefault | None:
+    value = next(
+        (
+            value
+            for scene_id, effect_id in _scene_default_identities(model, scene_key, entry)
+            if (value := repository.get(config_entry_id, scene_id, effect_id)) is not None
+        ),
+        None,
+    )
+    if value is None:
+        return None
+    speed_index = value.speed_index
+    if entry.speed is None:
+        speed_index = None
+    elif speed_index is None or not 0 <= speed_index < entry.speed.option_count:
+        speed_index = entry.speed.default_index
+    return replace(
+        value,
+        scene_id=entry.scene_id,
+        effect_id=entry.effect_id,
+        speed_index=speed_index,
+    )
+
+
+def _scene_default_identities(
+    model: str,
+    scene_key: str,
+    entry: SceneEntry,
+) -> tuple[tuple[int, int], ...]:
+    canonical_key = canonical_scene_key(model, scene_key)
+    official_entry = OFFICIAL_MODEL_SCENES.get(model, {}).get(canonical_key)
+    identities = [(official_entry.scene_id, official_entry.effect_id)] if official_entry is not None else []
+    entry_identity = (entry.scene_id, entry.effect_id)
+    if entry_identity not in identities:
+        identities.append(entry_identity)
+    for legacy_entry in legacy_scene_entries(model, canonical_key):
+        legacy_identity = (legacy_entry.scene_id, legacy_entry.effect_id)
+        if legacy_identity not in identities:
+            identities.append(legacy_identity)
+    return tuple(identities)
+
+
+async def async_delete_scene_defaults(
+    repository: NativeSceneDefaultRepository,
+    config_entry_id: str,
+    model: str,
+    resolved: ResolvedScene,
+) -> None:
+    await repository.async_replace_identities(
+        config_entry_id,
+        _scene_default_identities(model, resolved.key, resolved.entry),
+        None,
+    )
+
+
+async def async_store_scene_default(
+    repository: NativeSceneDefaultRepository,
+    config_entry_id: str,
+    model: str,
+    resolved: ResolvedScene,
+    *,
+    updated_at: str,
+    canonical_body: bytes,
+    speed_index: int | None,
+) -> None:
+    value = NativeSceneDefault(
+        config_entry_id=config_entry_id,
+        scene_id=resolved.entry.scene_id,
+        effect_id=resolved.entry.effect_id,
+        updated_at=updated_at,
+        canonical_body=canonical_body,
+        speed_index=speed_index,
+    )
+    await repository.async_replace_identities(
+        config_entry_id,
+        _scene_default_identities(model, resolved.key, resolved.entry),
+        value,
+    )
 
 
 def scene_catalogue_payload(model: str) -> dict[str, JsonValue]:
@@ -55,7 +146,7 @@ def scene_catalogue_payload(model: str) -> dict[str, JsonValue]:
     return {
         "schema_version": CATALOGUE_SCHEMA_VERSION,
         "sku": model,
-        "enabled": True,
+        "enabled": get_profile(model).supports_scenes,
         "categories": categories,
         "scenes": [_scene_summary(model, entry) for entry in entries],
     }
@@ -80,8 +171,8 @@ def scene_detail_payload(
     )
     template = CatalogueRef(
         sku=model,
-        scene_id=scene_id,
-        effect_id=effect_id,
+        scene_id=resolved.entry.scene_id,
+        effect_id=resolved.entry.effect_id,
         catalogue_schema_version=CATALOGUE_SCHEMA_VERSION,
     )
     catalogue_speed = resolved.entry.speed.default_index if resolved.entry.speed is not None else None
@@ -101,14 +192,14 @@ def scene_detail_payload(
 
 
 def resolve_scene(model: str, scene_id: int, effect_id: int) -> ResolvedScene:
-    scenes = MODEL_SCENES.get(model)
     labels = MODEL_SCENE_LABELS.get(model)
-    if scenes is None or labels is None:
-        raise ValueError(f"{model} has no native scene catalogue")
-    for key, entry in scenes.items():
-        if entry.scene_id == scene_id and entry.effect_id == effect_id:
-            return ResolvedScene(key, labels[key], entry)
-    raise ValueError(f"{model} scene identity ({scene_id}, {effect_id}) was not found")
+    resolved = resolve_scene_identity(model, scene_id, effect_id)
+    if resolved is None or labels is None:
+        if model not in MODEL_SCENES:
+            raise ValueError(f"{model} has no native scene catalogue")
+        raise ValueError(f"{model} scene identity ({scene_id}, {effect_id}) was not found")
+    key, entry = resolved
+    return ResolvedScene(key, labels.get(key, entry.display_name), entry)
 
 
 async def async_apply_scene(
@@ -124,7 +215,17 @@ async def async_apply_scene(
     del hass, user_id
     coordinator = config_entry.runtime_data
     resolved = resolve_scene(coordinator.model, scene_id, effect_id)
-    scene_default = scene_defaults.get(config_entry.entry_id, scene_id, effect_id) if scene_defaults else None
+    scene_default = (
+        scene_default_for(
+            scene_defaults,
+            config_entry.entry_id,
+            coordinator.model,
+            resolved.key,
+            resolved.entry,
+        )
+        if scene_defaults
+        else None
+    )
     canonical_body, resolved_speed = resolve_scene_application_body(
         resolved.entry,
         scene_default=scene_default,
@@ -133,6 +234,7 @@ async def async_apply_scene(
 
     await coordinator.async_apply_native_scene(
         resolved.key,
+        scene_entry=resolved.entry,
         speed_index=resolved_speed,
         canonical_body=canonical_body or None,
     )
@@ -148,7 +250,7 @@ async def async_reset_scene_default(
 ) -> ResolvedScene:
     coordinator = config_entry.runtime_data
     resolved = resolve_scene(coordinator.model, scene_id, effect_id)
-    await scene_defaults.async_delete(config_entry.entry_id, scene_id, effect_id)
+    await async_delete_scene_defaults(scene_defaults, config_entry.entry_id, coordinator.model, resolved)
     return resolved
 
 
@@ -175,17 +277,16 @@ async def async_set_scene_default(
         )
     catalogue_body, catalogue_speed = resolve_native_scene_body(resolved.entry)
     if canonical_body == catalogue_body and resolved_speed == catalogue_speed:
-        await scene_defaults.async_delete(config_entry.entry_id, scene_id, effect_id)
+        await async_delete_scene_defaults(scene_defaults, config_entry.entry_id, coordinator.model, resolved)
     elif canonical_body:
-        await scene_defaults.async_set(
-            NativeSceneDefault(
-                config_entry_id=config_entry.entry_id,
-                scene_id=scene_id,
-                effect_id=effect_id,
-                updated_at=updated_at,
-                canonical_body=canonical_body,
-                speed_index=resolved_speed,
-            )
+        await async_store_scene_default(
+            scene_defaults,
+            config_entry.entry_id,
+            coordinator.model,
+            resolved,
+            updated_at=updated_at,
+            canonical_body=canonical_body,
+            speed_index=resolved_speed,
         )
     return resolved
 

--- a/custom_components/ha_govee_led_ble/effect_selector.py
+++ b/custom_components/ha_govee_led_ble/effect_selector.py
@@ -25,7 +25,7 @@ from .const import (
 )
 from .effect_compiler import CompatibilityState, compatibility
 from .effect_domain import EffectValidationError, LibraryItem, effect_content_to_dict
-from .scenes import MODEL_SCENE_LABELS
+from .scenes import MODEL_SCENE_LABELS, scene_aliases
 
 _EFFECT_QUOTE_CHARS = "\"'“”‘’"
 
@@ -106,9 +106,15 @@ def effect_selector_entries(
         always_include_custom_effects=always_include_custom_effects,
         native_categories=native_categories,
     )
-    counts = Counter(normalise_effect_name(candidate.base_label) for candidate in candidates)
+    names_by_candidate = tuple(
+        frozenset(normalise_effect_name(name) for name in (candidate.base_label, *candidate.aliases))
+        for candidate in candidates
+    )
+    counts = Counter(name for names in names_by_candidate for name in names)
     category_counts = Counter(
-        (normalise_effect_name(candidate.base_label), candidate.category) for candidate in candidates
+        (name, candidate.category)
+        for candidate, names in zip(candidates, names_by_candidate, strict=True)
+        for name in names
     )
     counts[normalise_effect_name(EFFECT_OFF)] += 1
     if active_custom:
@@ -120,13 +126,10 @@ def effect_selector_entries(
             _project_candidate(
                 candidate,
                 use_prefix=use_prefixes,
-                collides=counts[normalise_effect_name(candidate.base_label)] > 1,
-                same_category_collides=category_counts[
-                    (normalise_effect_name(candidate.base_label), candidate.category)
-                ]
-                > 1,
+                collides=any(counts[name] > 1 for name in names),
+                same_category_collides=any(category_counts[(name, candidate.category)] > 1 for name in names),
             )
-            for candidate in candidates
+            for candidate, names in zip(candidates, names_by_candidate, strict=True)
         ),
         use_prefix=use_prefixes,
     )
@@ -247,7 +250,7 @@ def _selector_candidates(
                 category=EFFECT_CATEGORY_SCENES,
                 base_label=label,
                 value=key,
-                aliases=(key,),
+                aliases=(key, *_legacy_scene_selector_aliases(model, key)),
             )
             for key, label in MODEL_SCENE_LABELS[model].items()
         )
@@ -290,6 +293,25 @@ def _selector_candidates(
         and (category in categories or always_include_custom_effects)
     )
     return tuple(candidates)
+
+
+def _legacy_scene_selector_aliases(model: str, scene_key: str) -> tuple[str, ...]:
+    legacy_model = get_profile(model).legacy_scene_catalogue_sku
+    legacy_labels = MODEL_SCENE_LABELS.get(legacy_model or "", {})
+    aliases: list[str] = []
+    for alias in scene_aliases(model, scene_key):
+        label = legacy_labels.get(alias, alias)
+        aliases.extend(
+            (
+                alias,
+                label,
+                f"Scene: {label}",
+                f"{label} [Scene]",
+                f"Scene: {label} [Built-in]",
+                f"{label} [Scene, Built-in]",
+            )
+        )
+    return tuple(aliases)
 
 
 def _project_candidate(

--- a/custom_components/ha_govee_led_ble/effect_websocket.py
+++ b/custom_components/ha_govee_led_ble/effect_websocket.py
@@ -53,11 +53,14 @@ from .effect_preview import (
     PreviewStatus,
     PreviewTargetUnavailableError,
 )
+from .effect_runtime import observable_signatures_for_coordinator
 from .effect_scenes import (
     async_apply_scene,
     async_reset_scene_default,
     async_set_scene_default,
+    resolve_scene,
     scene_catalogue_payload,
+    scene_default_for,
     scene_detail_payload,
 )
 from .effect_selector import ReservedEffectNameError, SavedEffectNameConflictError
@@ -214,21 +217,11 @@ def _device_payload(
         workspace.to_dict()
         if workspace is not None
         and workspace.model == coordinator.model
-        and workspace.observable_signature == _observed_signature(observed)
+        and workspace.observable_signature in observable_signatures_for_coordinator(coordinator)
         else None
     )
     device["preview_health"] = backend.preview.health(entry.entry_id).to_dict()
     return device
-
-
-def _observed_signature(observed: Any) -> str | None:
-    if observed.mode == "custom" and observed.diy_code is not None:
-        return f"custom:{observed.diy_code}"
-    if observed.mode == "scene" and observed.effect is not None:
-        return f"scene:{observed.effect}"
-    if observed.mode in {"music", "video"} and observed.native_mode is not None:
-        return f"{observed.mode}:{observed.native_mode}"
-    return None
 
 
 def _light_entity_id(hass: HomeAssistant, config_entry_id: str) -> str | None:
@@ -369,14 +362,17 @@ def ws_scene_catalogue_get(
         return
     try:
         backend = _backend(hass)
+        resolved = resolve_scene(entry.runtime_data.model, msg["scene_id"], msg["effect_id"])
         detail = scene_detail_payload(
             entry.runtime_data.model,
             msg["scene_id"],
             msg["effect_id"],
-            scene_default=backend.scene_defaults.get(
+            scene_default=scene_default_for(
+                backend.scene_defaults,
                 entry.entry_id,
-                msg["scene_id"],
-                msg["effect_id"],
+                entry.runtime_data.model,
+                resolved.key,
+                resolved.entry,
             ),
         )
     except ValueError as exc:
@@ -439,10 +435,12 @@ async def ws_scene_apply(
                 entry.runtime_data.model,
                 resolved.entry.scene_id,
                 resolved.entry.effect_id,
-                scene_default=backend.scene_defaults.get(
+                scene_default=scene_default_for(
+                    backend.scene_defaults,
                     entry.entry_id,
-                    resolved.entry.scene_id,
-                    resolved.entry.effect_id,
+                    entry.runtime_data.model,
+                    resolved.key,
+                    resolved.entry,
                 ),
             )["scene"],
             "speed_index": speed_index,
@@ -537,10 +535,12 @@ async def ws_scene_default_set(
             entry.runtime_data.model,
             resolved.entry.scene_id,
             resolved.entry.effect_id,
-            scene_default=backend.scene_defaults.get(
+            scene_default=scene_default_for(
+                backend.scene_defaults,
                 entry.entry_id,
-                resolved.entry.scene_id,
-                resolved.entry.effect_id,
+                entry.runtime_data.model,
+                resolved.key,
+                resolved.entry,
             ),
         ),
     )

--- a/custom_components/ha_govee_led_ble/effect_websocket_payloads.py
+++ b/custom_components/ha_govee_led_ble/effect_websocket_payloads.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from .const import protocol_model
+from .const import protocol_model, resolve_model
 from .effect_deployments import DeploymentSnapshot
 from .effect_domain import (
     BuiltinScene,
@@ -40,16 +40,17 @@ def item_summary(item: LibraryItem) -> dict[str, Any]:
         }
         else None
     )
-    if model in {"H617A", "H617E", "H6199"}:
+    if isinstance(model, str) and resolve_model(model) is not None:
         summary["model"] = model
     elif kind in {"h617a_painted", "h617a_single", "h617a_multi"}:
         hinted_model = item.target_hint.model if item.target_hint is not None else None
         summary["model"] = hinted_model if protocol_model(hinted_model or "") == "H617A" else "H617A"
     elif kind in {"scene_builtin", "scene_palette", "scene_layered"}:
         template = content.get("template")
-        if isinstance(template, dict) and template.get("sku") in {"H617A", "H617E", "H6199"}:
-            summary["model"] = template["sku"]
-    elif item.target_hint is not None and item.target_hint.model in {"H617A", "H617E", "H6199"}:
+        sku = template.get("sku") if isinstance(template, dict) else None
+        if isinstance(sku, str) and resolve_model(sku) is not None:
+            summary["model"] = sku
+    elif item.target_hint is not None and resolve_model(item.target_hint.model) is not None:
         summary["model"] = item.target_hint.model
     if isinstance(item.content, BuiltinScene | PaletteScene | LayeredScene):
         summary["template"] = content["template"]

--- a/custom_components/ha_govee_led_ble/light.py
+++ b/custom_components/ha_govee_led_ble/light.py
@@ -47,7 +47,11 @@ from .effect_compiler import CompiledMusicProfile, CompiledVideoProfile, compile
 from .effect_deployments import DeploymentRecord
 from .effect_diagnostics import DiagnosticOutcome, DiagnosticStage
 from .effect_domain import EffectValidationError, LibraryItem, effect_content_to_dict
-from .effect_runtime import async_apply_compiled_profile, observable_signature_for_coordinator
+from .effect_runtime import (
+    async_apply_compiled_profile,
+    observable_signatures_for_coordinator,
+)
+from .effect_scenes import scene_default_for
 from .effect_selector import (
     EffectSelectorEntry,
     effect_selector_entries,
@@ -349,10 +353,9 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
         hint = observed.active_effect if observed is not None else None
         if hint is None or hint.source_kind != "saved_effect" or hint.item_id is None:
             return None
-        observable_signature = observable_signature_for_coordinator(self.coordinator)
         if self._matching_active_workspace() is not None:
             return None
-        if hint.observable_signature != observable_signature:
+        if hint.observable_signature not in observable_signatures_for_coordinator(self.coordinator):
             return None
         item = next(
             (
@@ -382,11 +385,11 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
             return None
         active_workspaces = getattr(self._effect_backend, "active_workspaces", None)
         workspace = active_workspaces.get(self._config_entry_id) if active_workspaces is not None else None
-        observable_signature = observable_signature_for_coordinator(self.coordinator)
+        observable_signatures = observable_signatures_for_coordinator(self.coordinator)
         if (
             workspace is None
             or workspace.model != self.coordinator.model
-            or workspace.observable_signature != observable_signature
+            or workspace.observable_signature not in observable_signatures
         ):
             return None
         return workspace
@@ -598,10 +601,12 @@ class GoveeBLELight(_GoveeLightServicesMixin, GoveeBLEEntity, RestoreEntity, Lig
         if selected is not None and selected.source == "scene":
             scene = MODEL_SCENES[coordinator.model][selected.value]
             scene_default = (
-                self._effect_backend.scene_defaults.get(
+                scene_default_for(
+                    self._effect_backend.scene_defaults,
                     self._config_entry_id,
-                    scene.scene_id,
-                    scene.effect_id,
+                    coordinator.model,
+                    selected.value,
+                    scene,
                 )
                 if self._effect_backend is not None and self._config_entry_id is not None
                 else None

--- a/custom_components/ha_govee_led_ble/scenes.py
+++ b/custom_components/ha_govee_led_ble/scenes.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from .const import MODEL_PROFILES
+
 CATALOGUE_DIR = Path(__file__).with_name("scene_catalogues")
 
 
@@ -123,8 +125,11 @@ def _load_catalogue(sku: str) -> tuple[SceneEntry, ...]:
     return entries
 
 
-SCENE_ENTRIES: dict[str, tuple[SceneEntry, ...]] = {sku: _load_catalogue(sku) for sku in ("H617A", "H6199")}
-SCENE_ENTRIES["H617E"] = SCENE_ENTRIES["H617A"]
+SCENE_ENTRIES: dict[str, tuple[SceneEntry, ...]] = {
+    model: _load_catalogue(profile.scene_catalogue_sku)
+    for model, profile in MODEL_PROFILES.items()
+    if profile.scene_catalogue_sku is not None
+}
 
 
 def _legacy_h617a_key(entry: SceneEntry) -> str:
@@ -151,8 +156,134 @@ def _model_scene_catalogue(sku: str) -> tuple[dict[str, SceneEntry], dict[str, s
 
 
 _MODEL_CATALOGUES = {sku: _model_scene_catalogue(sku) for sku in SCENE_ENTRIES}
-MODEL_SCENES: dict[str, dict[str, SceneEntry]] = {sku: catalogue[0] for sku, catalogue in _MODEL_CATALOGUES.items()}
-MODEL_SCENE_LABELS: dict[str, dict[str, str]] = {sku: catalogue[1] for sku, catalogue in _MODEL_CATALOGUES.items()}
+OFFICIAL_MODEL_SCENES: dict[str, dict[str, SceneEntry]] = {
+    sku: dict(catalogue[0]) for sku, catalogue in _MODEL_CATALOGUES.items()
+}
+MODEL_SCENES: dict[str, dict[str, SceneEntry]] = {sku: dict(scenes) for sku, scenes in OFFICIAL_MODEL_SCENES.items()}
+MODEL_SCENE_LABELS: dict[str, dict[str, str]] = {
+    sku: dict(catalogue[1]) for sku, catalogue in _MODEL_CATALOGUES.items()
+}
+MODEL_SCENE_ALIASES: dict[str, dict[str, str]] = {}
 
 # H617A protocol and service lookups use the legacy unhyphenated variant names.
 SCENES: dict[str, SceneEntry] = {_legacy_h617a_key(entry): entry for entry in SCENE_ENTRIES["H617A"]}
+
+
+def _legacy_scene_target(
+    scenes: dict[str, SceneEntry],
+    legacy_key: str,
+    legacy_entry: SceneEntry,
+) -> str | None:
+    if legacy_key in scenes:
+        return legacy_key
+    matches = [
+        key
+        for key, entry in scenes.items()
+        if legacy_entry.param and entry.scene_type == legacy_entry.scene_type and entry.param == legacy_entry.param
+    ] or [
+        key
+        for key, entry in scenes.items()
+        if entry.scene_type == legacy_entry.scene_type and entry.code == legacy_entry.code
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+for _model, _profile in MODEL_PROFILES.items():
+    _legacy_model = _profile.legacy_scene_catalogue_sku
+    if _legacy_model is None or _model not in MODEL_SCENES or _legacy_model not in MODEL_SCENES:
+        continue
+    _scenes = MODEL_SCENES[_model]
+    _labels = MODEL_SCENE_LABELS[_model]
+    _aliases: dict[str, str] = {}
+    for _legacy_key, _legacy_entry in MODEL_SCENES[_legacy_model].items():
+        _target = _legacy_scene_target(_scenes, _legacy_key, _legacy_entry)
+        if _target is None:
+            _scenes[_legacy_key] = _legacy_entry
+            _labels[_legacy_key] = _legacy_entry.display_name
+        elif _target != _legacy_key:
+            _aliases[_legacy_key] = _target
+    MODEL_SCENE_ALIASES[_model] = _aliases
+
+
+def scene_aliases(model: str, scene_key: str) -> tuple[str, ...]:
+    return tuple(alias for alias, target in MODEL_SCENE_ALIASES.get(model, {}).items() if target == scene_key)
+
+
+def canonical_scene_key(model: str, scene_key: str) -> str:
+    return MODEL_SCENE_ALIASES.get(model, {}).get(scene_key, scene_key)
+
+
+def resolve_scene_code(
+    model: str,
+    scene_code: int,
+    *,
+    preferred_key: str | None = None,
+) -> tuple[str, SceneEntry] | None:
+    legacy_model = MODEL_PROFILES[model].legacy_scene_catalogue_sku
+    if preferred_key is not None:
+        preferred = OFFICIAL_MODEL_SCENES.get(model, {}).get(preferred_key)
+        if preferred is not None and preferred.code == scene_code:
+            return preferred_key, preferred
+        legacy = MODEL_SCENES.get(legacy_model or "", {}).get(preferred_key)
+        if legacy is not None and legacy.code == scene_code:
+            return preferred_key, legacy
+        canonical_key = canonical_scene_key(model, preferred_key)
+        canonical = OFFICIAL_MODEL_SCENES.get(model, {}).get(canonical_key)
+        if canonical is not None and canonical.code == scene_code:
+            return canonical_key, canonical
+
+    resolved = next(
+        ((key, entry) for key, entry in MODEL_SCENES.get(model, {}).items() if entry.code == scene_code),
+        None,
+    )
+    if resolved is not None:
+        return resolved
+    return next(
+        ((key, entry) for key, entry in MODEL_SCENES.get(legacy_model or "", {}).items() if entry.code == scene_code),
+        None,
+    )
+
+
+def scene_code_is_ambiguous(model: str, scene_code: int) -> bool:
+    exact_keys = {key for key, entry in OFFICIAL_MODEL_SCENES.get(model, {}).items() if entry.code == scene_code}
+    legacy_model = MODEL_PROFILES[model].legacy_scene_catalogue_sku
+    legacy_keys = {
+        MODEL_SCENE_ALIASES.get(model, {}).get(key, key)
+        for key, entry in MODEL_SCENES.get(legacy_model or "", {}).items()
+        if entry.code == scene_code
+    }
+    return bool(exact_keys and legacy_keys and exact_keys != legacy_keys)
+
+
+def legacy_scene_entries(model: str, scene_key: str) -> tuple[SceneEntry, ...]:
+    legacy_model = MODEL_PROFILES[model].legacy_scene_catalogue_sku
+    legacy_scenes = MODEL_SCENES.get(legacy_model or "", {})
+    aliases = MODEL_SCENE_ALIASES.get(model, {})
+    return tuple(
+        entry for legacy_key, entry in legacy_scenes.items() if aliases.get(legacy_key, legacy_key) == scene_key
+    )
+
+
+def resolve_scene_identity(model: str, scene_id: int, effect_id: int) -> tuple[str, SceneEntry] | None:
+    scenes = MODEL_SCENES.get(model)
+    if scenes is None:
+        return None
+    resolved = next(
+        ((key, entry) for key, entry in scenes.items() if entry.scene_id == scene_id and entry.effect_id == effect_id),
+        None,
+    )
+    if resolved is not None:
+        return resolved
+
+    legacy_model = MODEL_PROFILES[model].legacy_scene_catalogue_sku
+    legacy_scenes = MODEL_SCENES.get(legacy_model or "")
+    if legacy_scenes is None:
+        return None
+    return next(
+        (
+            (key, entry)
+            for key, entry in legacy_scenes.items()
+            if entry.scene_id == scene_id and entry.effect_id == effect_id
+        ),
+        None,
+    )

--- a/frontend/src/catalogue-validation.ts
+++ b/frontend/src/catalogue-validation.ts
@@ -19,7 +19,6 @@ import type {
   EffectStudioCatalogue,
   EffectStudioModeOption,
   ModelEffectCatalogue,
-  ModelSku,
   PaintedContent,
   PaintedEffectTemplate,
   PaletteDiyFamily,
@@ -34,9 +33,6 @@ import {
   MAX_CATALOGUE_JSON_NODES,
   MAX_EFFECT_NAME_LENGTH,
   MAX_IDENTIFIER_LENGTH,
-  MODEL_SKUS,
-  isH617xModel,
-  VIDEO_MODE_IDS,
 } from "./validation-constants";
 
 const RELEASE_WORKFLOW_IDS = [
@@ -57,41 +53,6 @@ const RELEASE_WORKFLOW_APPLICATIONS = [
   "home_assistant",
   "planned",
 ] as const;
-const MODEL_RELEASE_WORKFLOWS: Record<ModelSku, readonly ReleaseWorkflowId[]> = {
-  H617A: [
-    "native_scenes",
-    "edited_palette_scenes",
-    "layered_scenes",
-    "painted",
-    "single",
-    "multi",
-    "native_music",
-    "advanced",
-    "workshop",
-  ],
-  H617E: [
-    "native_scenes",
-    "edited_palette_scenes",
-    "layered_scenes",
-    "painted",
-    "single",
-    "multi",
-    "native_music",
-    "advanced",
-    "workshop",
-  ],
-  H6199: [
-    "native_scenes",
-    "edited_palette_scenes",
-    "layered_scenes",
-    "palette_diy",
-    "native_music",
-    "video",
-    "advanced",
-    "workshop",
-  ],
-};
-
 export function decodeCustomCataloguePayload(
   value: unknown,
   decodeContent: (value: unknown) => EffectContent,
@@ -115,7 +76,7 @@ export function decodeCustomCataloguePayload(
     JSON.stringify(models[LEGACY_CUSTOM_CATALOGUE_SKU])
   ) {
     throw new Error(
-      "Malformed Effect Studio server payload: legacy custom-effect catalogue view does not match models.H617A.",
+      `Malformed Effect Studio server payload: legacy custom-effect catalogue view does not match models.${LEGACY_CUSTOM_CATALOGUE_SKU}.`,
     );
   }
   exactInteger(
@@ -135,49 +96,37 @@ export function decodeCustomCataloguePayload(
 function decodeModelCatalogues(
   value: unknown,
   decodeContent: (value: unknown) => EffectContent,
-): Record<ModelSku, ModelEffectCatalogue> {
+): Record<string, ModelEffectCatalogue> {
   const models = objectValue(value, "custom-effect catalogue models");
-  const unexpected = Object.keys(models).filter(
-    (key) => !MODEL_SKUS.includes(key as ModelSku),
-  );
-  if (unexpected.length > 0) {
+  if (!Object.hasOwn(models, LEGACY_CUSTOM_CATALOGUE_SKU)) {
     throw new Error(
-      `Malformed Effect Studio server payload: unexpected catalogue models ${unexpected.join(", ")}.`,
+      `Malformed Effect Studio server payload: missing catalogue model ${LEGACY_CUSTOM_CATALOGUE_SKU}.`,
     );
   }
-  for (const sku of MODEL_SKUS) {
-    if (!(sku in models)) {
-      throw new Error(
-        `Malformed Effect Studio server payload: missing catalogue model ${sku}.`,
+  return Object.fromEntries(
+    Object.entries(models).map(([key, catalogue]) => {
+      const model = boundedString(
+        key,
+        "catalogue model key",
+        MAX_IDENTIFIER_LENGTH,
       );
-    }
-  }
-  return {
-    H617A: decodeModelEffectCatalogue(
-      models.H617A,
-      "catalogue model H617A",
-      "H617A",
-      decodeContent,
-    ),
-    H617E: decodeModelEffectCatalogue(
-      models.H617E,
-      "catalogue model H617E",
-      "H617E",
-      decodeContent,
-    ),
-    H6199: decodeModelEffectCatalogue(
-      models.H6199,
-      "catalogue model H6199",
-      "H6199",
-      decodeContent,
-    ),
-  };
+      return [
+        model,
+        decodeModelEffectCatalogue(
+          catalogue,
+          `catalogue model ${model}`,
+          model,
+          decodeContent,
+        ),
+      ];
+    }),
+  );
 }
 
 function decodeModelEffectCatalogue(
   value: unknown,
   name: string,
-  expectedSku: ModelSku,
+  expectedSku: string,
   decodeContent: (value: unknown) => EffectContent,
 ): ModelEffectCatalogue {
   const catalogue = objectValue(value, name);
@@ -187,7 +136,11 @@ function decodeModelEffectCatalogue(
     `${name} support capabilities`,
   );
   const apply = objectValue(catalogue.apply, `${name} Apply capabilities`);
-  const sku = enumString(catalogue.sku, MODEL_SKUS, `${name} SKU`) as ModelSku;
+  const sku = boundedString(
+    catalogue.sku,
+    `${name} SKU`,
+    MAX_IDENTIFIER_LENGTH,
+  );
   if (sku !== expectedSku) {
     throw new Error(
       `Malformed Effect Studio server payload: ${name} is keyed as ${expectedSku} but declares ${sku}.`,
@@ -225,7 +178,6 @@ function decodeModelEffectCatalogue(
     video_modes: decodeModeOptions(
       catalogue.video_modes,
       `${name} video modes`,
-      VIDEO_MODE_IDS,
     ),
     templates: decodeCatalogueTemplates(
       catalogue.templates,
@@ -242,7 +194,6 @@ function decodeModelEffectCatalogue(
     workflows: decodeReleaseWorkflows(
       catalogue.workflows,
       `${name} release workflows`,
-      expectedSku,
     ),
     supports: {
       multi: capabilityValue(supports.multi, `${name} Multi support`),
@@ -302,7 +253,7 @@ function decodeModelEffectCatalogue(
 function decodeCatalogueTemplates(
   value: unknown,
   name: string,
-  model: ModelSku,
+  model: string,
   decodeContent: (value: unknown) => EffectContent,
 ): CatalogueTemplate[] {
   const templates = arrayValue(value, name, MAX_JSON_COLLECTION_ITEMS).map(
@@ -319,9 +270,8 @@ function decodeCatalogueTemplates(
         invalid(`${name}[${index}] content is not a supported built-in template`);
       }
       if (
-        ("model" in content && content.model !== model) ||
-        (content.kind === "h617a_painted" && !isH617xModel(model)) ||
-        (content.kind === "h617a_single" && !isH617xModel(model))
+        "model" in content &&
+        content.model !== model
       ) {
         invalid(`${name}[${index}] content does not target ${model}`);
       }
@@ -352,7 +302,6 @@ function decodeCatalogueTemplates(
 function decodeReleaseWorkflows(
   value: unknown,
   name: string,
-  model: ModelSku,
 ): ReleaseWorkflowCapability[] {
   const workflows = arrayValue(value, name, RELEASE_WORKFLOW_IDS.length).map(
     (item, index): ReleaseWorkflowCapability => {
@@ -382,17 +331,6 @@ function decodeReleaseWorkflows(
     },
   );
   requireUnique(workflows, (workflow) => workflow.id, `${name} IDs`);
-  const expected = MODEL_RELEASE_WORKFLOWS[model];
-  const actual = new Set(workflows.map((workflow) => workflow.id));
-  const missing = expected.filter((workflow) => !actual.has(workflow));
-  const unexpected = workflows
-    .map((workflow) => workflow.id)
-    .filter((workflow) => !expected.includes(workflow));
-  if (missing.length > 0 || unexpected.length > 0) {
-    throw new Error(
-      `Malformed Effect Studio server payload: ${name} does not match ${model}.`,
-    );
-  }
   return workflows;
 }
 
@@ -518,19 +456,16 @@ function decodePaletteDiyFamilies(
 function decodeModeOptions(
   value: unknown,
   name: string,
-  allowedIds?: readonly string[],
 ): EffectStudioModeOption[] {
   const modes = arrayValue(value, name, MAX_JSON_COLLECTION_ITEMS).map(
     (item, index) => {
       const mode = objectValue(item, `${name}[${index}]`);
       return {
-        id: allowedIds
-          ? enumString(mode.id, allowedIds, `${name}[${index}] ID`)
-          : boundedString(
-              mode.id,
-              `${name}[${index}] ID`,
-              MAX_IDENTIFIER_LENGTH,
-            ),
+        id: boundedString(
+          mode.id,
+          `${name}[${index}] ID`,
+          MAX_IDENTIFIER_LENGTH,
+        ),
         label: boundedString(
           mode.label,
           `${name}[${index}] label`,
@@ -546,7 +481,7 @@ function decodeModeOptions(
 function decodeWorkshopTemplates(
   value: unknown,
   name: string,
-  model: ModelSku,
+  model: string,
   decodeContent: (value: unknown) => EffectContent,
 ): WorkshopTemplate[] {
   const templates = arrayValue(value, name, MAX_JSON_COLLECTION_ITEMS).map(

--- a/frontend/src/custom-effect-list.ts
+++ b/frontend/src/custom-effect-list.ts
@@ -10,7 +10,6 @@ import type {
   ModelSku,
 } from "./types";
 import { compareLabels } from "./ui-utils";
-import { isH617xModel } from "./validation-constants";
 
 export interface CustomEffectListContext {
   model?: ModelSku;
@@ -114,23 +113,20 @@ export function libraryItemAvailable(
   context: CustomEffectListContext,
   item: LibrarySummary,
 ): boolean {
-  const h617xContent = ["h617a_painted", "h617a_single", "h617a_multi"].includes(item.kind);
+  const modelIndependentContent = [
+    "h617a_painted",
+    "h617a_single",
+    "h617a_multi",
+  ].includes(item.kind);
   if (
     item.model !== undefined &&
     item.model !== context.model &&
-    !(h617xContent && isH617xModel(item.model) && isH617xModel(context.model))
+    !modelIndependentContent
   ) {
     return false;
   }
   if (item.kind === "video_profile") {
     return Boolean(context.catalogue?.video_modes.length);
-  }
-  if (
-    item.model === undefined &&
-    h617xContent &&
-    !isH617xModel(context.model)
-  ) {
-    return false;
   }
   return customEffectKindAvailable(context, item.kind);
 }
@@ -167,32 +163,43 @@ export function customEffectKindAvailable(
   kind: string,
 ): boolean {
   const catalogue = context.catalogue;
+  if (!catalogue) {
+    return false;
+  }
   if (kind === "h617a_painted") {
     return (
-      isH617xModel(context.model) && Boolean(catalogue?.painted_effects.length)
+      Boolean(catalogue.painted_effects.length) &&
+      catalogue.apply.painted !== "unsupported"
     );
   }
   if (kind === "h617a_single") {
-    return isH617xModel(context.model) && Boolean(catalogue?.effects.length);
+    return (
+      Boolean(catalogue.effects.length) &&
+      catalogue.apply.single !== "unsupported"
+    );
   }
   if (kind === "palette_diy") {
-    return context.model === "H6199" && Boolean(catalogue?.effects.length);
+    return (
+      Boolean(catalogue.effects.length) &&
+      catalogue.apply.palette_diy !== "unsupported"
+    );
   }
   if (kind === "h617a_multi") {
     return (
-      isH617xModel(context.model) && catalogue?.supports.multi !== "unsupported"
+      catalogue.supports.multi !== "unsupported" &&
+      catalogue.apply.multi !== "unsupported"
     );
   }
   if (kind === "music_profile") {
-    return Boolean(catalogue?.music_modes.length);
+    return Boolean(catalogue.music_modes.length);
   }
   if (kind === "workshop") {
     return (
-      catalogue !== undefined &&
-      catalogue.supports.workshop !== "unsupported"
+      catalogue.supports.workshop !== "unsupported" &&
+      catalogue.apply.workshop !== "unsupported"
     );
   }
-  return catalogue?.supports.advanced !== "unsupported";
+  return catalogue.supports.advanced !== "unsupported";
 }
 
 export function newEffectKindForCategory(
@@ -233,7 +240,9 @@ function customEffectEntryAvailable(
     case "single":
       return customEffectKindAvailable(
         context,
-        isH617xModel(context.model) ? "h617a_single" : "palette_diy",
+        customEffectKindAvailable(context, "h617a_single")
+          ? "h617a_single"
+          : "palette_diy",
       );
     case "music":
       return customEffectKindAvailable(context, "music_profile");

--- a/frontend/src/effect-editor-model.ts
+++ b/frontend/src/effect-editor-model.ts
@@ -28,7 +28,7 @@ import type {
   WorkshopContent,
 } from "./types";
 import { clonePalette, cloneRgb, sameRgb } from "./ui-utils";
-import { isModelSku } from "./validation-constants";
+import { LEGACY_CUSTOM_CATALOGUE_SKU } from "./validation-constants";
 
 type AdvancedEditableContent =
   | AdvancedContent
@@ -186,8 +186,10 @@ export function blankPaletteDiy(
   family?: number,
   variant?: number,
 ): PaletteDiyEffectContent {
-  if (!isModelSku(model)) {
-    throw new Error(`Unsupported custom-effect model ${model}.`);
+  if (catalogue.sku !== model) {
+    throw new Error(
+      `Custom-effect catalogue ${catalogue.sku} does not target ${model}.`,
+    );
   }
   const selected =
     catalogue.effects.find((effect) => effect.family === family) ??
@@ -202,26 +204,6 @@ export function blankPaletteDiy(
     variant: variant ?? selected.variations[0].variant,
     speed: 50,
     palette: defaultPalette(),
-  };
-}
-
-export function blankVideoProfile(mode: string): VideoProfileContent {
-  return {
-    kind: "video_profile",
-    model: "H6199",
-    mode: mode === "game" ? "game" : "movie",
-    full_screen: true,
-    saturation: 50,
-    sound_effects: false,
-    sound_effects_softness: 50,
-    white_balance_position: 17,
-    relative_brightness: {
-      left: 100,
-      top: 100,
-      right: 100,
-      bottom: 100,
-    },
-    blank_screen: false,
   };
 }
 
@@ -515,26 +497,28 @@ export function isMyEffectKind(kind: string): boolean {
 
 export function libraryKindPriority(
   kind: string,
-  model: ModelSku | undefined,
+  catalogue: ModelEffectCatalogue | undefined,
 ): number {
-  const order =
-    model === "H6199"
-      ? [
-          "palette_diy",
-          "workshop",
-          "music_profile",
-          "advanced",
-          "scene_layered",
-        ]
-      : [
-          "h617a_painted",
-          "h617a_single",
-          "h617a_multi",
-          "music_profile",
-          "workshop",
-          "advanced",
-          "scene_layered",
-        ];
+  const paletteDiyFirst =
+    catalogue?.apply.palette_diy !== "unsupported" &&
+    catalogue?.apply.single === "unsupported";
+  const order = paletteDiyFirst
+    ? [
+        "palette_diy",
+        "workshop",
+        "music_profile",
+        "advanced",
+        "scene_layered",
+      ]
+    : [
+        "h617a_painted",
+        "h617a_single",
+        "h617a_multi",
+        "music_profile",
+        "workshop",
+        "advanced",
+        "scene_layered",
+      ];
   const priority = order.indexOf(kind);
   return priority === -1 ? order.length : priority;
 }
@@ -631,21 +615,14 @@ function libraryItemModel(item: LibraryItem): ModelSku | undefined {
     content.kind === "h617a_single" ||
     content.kind === "h617a_multi"
   ) {
-    return knownModel(item.target_hint?.model) ?? "H617A";
+    return item.target_hint?.model ?? LEGACY_CUSTOM_CATALOGUE_SKU;
   }
   if (
     content.kind === "scene_builtin" ||
     content.kind === "scene_palette" ||
     content.kind === "scene_layered"
   ) {
-    return knownModel(content.template.sku);
+    return content.template.sku;
   }
-  return knownModel(item.target_hint?.model);
-}
-
-function knownModel(
-  model: string | null | undefined,
-): ModelSku | undefined {
-  const candidate = model ?? undefined;
-  return isModelSku(candidate) ? candidate : undefined;
+  return item.target_hint?.model ?? undefined;
 }

--- a/frontend/src/panel-controller.ts
+++ b/frontend/src/panel-controller.ts
@@ -374,14 +374,14 @@ export class PanelController {
   }
 
   public async selectVideoTemplate(
-    mode: string,
+    templateId: string,
     label: string,
     returnFocus?: HTMLElement,
   ): Promise<void> {
     await this.requestTransition(
       async () => {
         await this.openCatalogueTemplate(
-          `template:video:${mode}`,
+          templateId,
           label,
           { section: "video" },
           this.editor.beginSelectionTransition(),
@@ -513,9 +513,13 @@ export class PanelController {
         return;
       }
       if (context.section === "video") {
+        const template = this.model.videoTemplate(context.mode);
+        if (!template) {
+          return;
+        }
         await this.openCatalogueTemplate(
-          `template:video:${context.mode}`,
-          context.label,
+          template.id,
+          template.label,
           { section: "video" },
           transitionEpoch,
           false,

--- a/frontend/src/panel-editor-controller.ts
+++ b/frontend/src/panel-editor-controller.ts
@@ -6,7 +6,6 @@ import {
   blankCustomEffect,
   blankPainted,
   blankPaletteDiy,
-  blankVideoProfile,
   cloneCustomEffect,
   cloneEditableEffect,
   cloneOpaqueContent,
@@ -41,7 +40,6 @@ import type {
   RGB,
   VideoProfileContent,
 } from "./types";
-import { isH617xModel } from "./validation-constants";
 
 interface PanelEditorOptions {
   apiReady(): boolean;
@@ -114,7 +112,7 @@ export class PanelEditorController {
     } else {
       const catalogue = this.model.modelCatalogue;
       if (!catalogue) return;
-      if (isH617xModel(this.model.selectedModel)) {
+      if (this.model.customEffectKindAvailable("h617a_single")) {
         const content = blankCustomEffect("h617a_single", catalogue);
         this.openEditableTemplate(
           entry.label,
@@ -123,7 +121,7 @@ export class PanelEditorController {
           { section: "custom", category: entry.category },
           true,
         );
-      } else {
+      } else if (this.model.customEffectKindAvailable("palette_diy")) {
         this.openEditableTemplate(
           entry.label,
           blankPaletteDiy(catalogue, this.model.selectedModel!, entry.family, entry.variant),
@@ -159,11 +157,12 @@ export class PanelEditorController {
     explicit = true,
     existingTransitionEpoch?: number,
   ): void {
-    if (this.model.selectedModel === "H6199") {
+    const template = this.model.videoTemplate(mode);
+    if (this.model.videoAvailable && template) {
       this.openEditableTemplate(
         label,
-        blankVideoProfile(mode),
-        `template:video:${mode}`,
+        cloneVideoProfileContent(template.content),
+        template.id,
         { section: "video" },
         explicit,
         existingTransitionEpoch,
@@ -786,14 +785,19 @@ export class PanelEditorController {
 
   private musicTemplateContent(mode: string): MusicProfileContent | undefined {
     const selectedModel = this.model.selectedModel;
-    if (!selectedModel || !mode) {
+    const catalogue = this.model.modelCatalogue;
+    if (
+      !selectedModel ||
+      !catalogue ||
+      !catalogue.music_modes.some((candidate) => candidate.id === mode)
+    ) {
       return undefined;
     }
     return {
       kind: "music_profile",
       model: selectedModel,
       mode,
-      sensitivity: selectedModel === "H6199" ? 100 : 99,
+      sensitivity: catalogue.limits.music_sensitivity_max,
       colour: null,
       calm: ["rhythm", "bloom", "shiny"].includes(mode) ? false : null,
       parameters: {},
@@ -824,7 +828,6 @@ export class PanelEditorController {
     }
     if (
       content.kind === "h617a_painted" &&
-      isH617xModel(selectedModel) &&
       this.model.customEffectKindAvailable(content.kind)
     ) {
       return {
@@ -834,8 +837,11 @@ export class PanelEditorController {
       };
     }
     if (
-      (content.kind === "h617a_single" && isH617xModel(selectedModel)) ||
-      (content.kind === "palette_diy" && content.model === selectedModel)
+      (content.kind === "h617a_single" &&
+        this.model.customEffectKindAvailable(content.kind)) ||
+      (content.kind === "palette_diy" &&
+        content.model === selectedModel &&
+        this.model.customEffectKindAvailable(content.kind))
     ) {
       const matches = catalogue.effects.flatMap((family) =>
         family.family === content.family
@@ -888,16 +894,15 @@ export class PanelEditorController {
     }
     if (
       content.kind === "video_profile" &&
-      selectedModel === "H6199"
+      content.model === selectedModel &&
+      this.model.videoAvailable
     ) {
-      const modes = catalogue.video_modes.filter(
-        (mode) => mode.id === content.mode,
-      );
-      return modes.length === 1
+      const template = this.model.videoTemplate(content.mode);
+      return template
         ? {
-            selectionIdentity: `template:video:${modes[0].id}`,
-            label: modes[0].label,
-            resetContent: blankVideoProfile(modes[0].id),
+            selectionIdentity: template.id,
+            label: template.label,
+            resetContent: cloneVideoProfileContent(template.content),
           }
         : undefined;
     }

--- a/frontend/src/panel-model.ts
+++ b/frontend/src/panel-model.ts
@@ -23,12 +23,15 @@ import {
   type PaintedSegmentDraft,
 } from "./effect-editor-model";
 import type { SceneInitialSelection } from "./scene-browser";
-import type { StudioSection } from "./studio-navigation";
+import {
+  videoCatalogueTemplate,
+  videoCatalogueTemplates,
+  type StudioSection,
+} from "./studio-navigation";
 import type {
   CustomEffectCatalogue, DeviceCapabilities, DiyEffectFamily, EffectContent, EffectUserState, LibraryItem, LibrarySnapshot,
   LibrarySummary, HomeAssistant, ModelEffectCatalogue, ModelSku, PreviewStatus, RGB,
 } from "./types";
-import { isModelSku } from "./validation-constants";
 
 export type DeleteCandidate = Pick<LibrarySummary, "id" | "version" | "updated_at" | "name"> & {
   discardsOpenEdits?: boolean;
@@ -233,8 +236,7 @@ export class PanelModel {
   }
 
   public get selectedModel(): ModelSku | undefined {
-    const model = this.selectedDevice?.model;
-    return isModelSku(model) ? model : undefined;
+    return this.selectedDevice?.model;
   }
 
   public get showDeviceSelector(): boolean {
@@ -289,8 +291,23 @@ export class PanelModel {
   public get videoAvailable(): boolean {
     return (
       this.effectCategoryEnabled("video") &&
-      Boolean(this.modelCatalogue?.video_modes.length)
+      this.selectedDevice?.profiles.video !== "unsupported" &&
+      this.videoTemplates.length > 0
     );
+  }
+
+  public get videoTemplates() {
+    if (
+      !this.effectCategoryEnabled("video") ||
+      this.selectedDevice?.profiles.video === "unsupported"
+    ) {
+      return [];
+    }
+    return videoCatalogueTemplates(this.modelCatalogue);
+  }
+
+  public videoTemplate(mode: string) {
+    return videoCatalogueTemplate(this.modelCatalogue, mode);
   }
 
   public get customEffectsAvailable(): boolean {

--- a/frontend/src/panel.ts
+++ b/frontend/src/panel.ts
@@ -780,14 +780,14 @@ export class GoveeLedEffectStudio extends LitElement {
       .sort((left, right) => compareLabels(left.name, right.name));
     return html`
       <aside class="sidebar item-sidebar library" aria-label="Video profiles">
-        ${catalogue.video_modes.map((mode) =>
+        ${this.model.videoTemplates.map((template) =>
           this.videoListButton(
-            `template:video:${mode.id}`,
-            mode.label,
+            template.id,
+            template.label,
             (returnFocus) =>
               void this.controller.selectVideoTemplate(
-                mode.id,
-                mode.label,
+                template.id,
+                template.label,
                 returnFocus,
               ),
           ),

--- a/frontend/src/studio-navigation.ts
+++ b/frontend/src/studio-navigation.ts
@@ -1,10 +1,12 @@
 import type {
+  CatalogueTemplate,
   DeviceCapabilities,
   EffectContent,
   EffectUserState,
   LibraryOrigin,
   LibrarySummary,
   ModelEffectCatalogue,
+  VideoProfileContent,
 } from "./types";
 import type { CustomEffectCategory } from "./effect-editor-model";
 
@@ -35,6 +37,35 @@ export type ActiveStudioContext =
       label: string;
     }
   | { kind: "root" };
+
+export type VideoCatalogueTemplate = CatalogueTemplate & {
+  content: VideoProfileContent;
+};
+
+export function videoCatalogueTemplates(
+  catalogue: ModelEffectCatalogue | undefined,
+): VideoCatalogueTemplate[] {
+  if (!catalogue) {
+    return [];
+  }
+  const modes = new Set(catalogue.video_modes.map((mode) => mode.id));
+  return (catalogue.templates ?? []).filter(
+    (template): template is VideoCatalogueTemplate =>
+      template.category === "video" &&
+      template.content.kind === "video_profile" &&
+      template.content.model === catalogue.sku &&
+      modes.has(template.content.mode),
+  );
+}
+
+export function videoCatalogueTemplate(
+  catalogue: ModelEffectCatalogue | undefined,
+  mode: string,
+): VideoCatalogueTemplate | undefined {
+  return videoCatalogueTemplates(catalogue).find(
+    (template) => template.content.mode === mode,
+  );
+}
 
 export function deviceIdFromEditorPath(pathname: string): string | undefined {
   const match = pathname.match(/^\/ha-govee-led-ble\/editor\/([^/]+)\/?$/);
@@ -177,15 +208,13 @@ export function activeStudioContext(
     return { kind: "native-scene", effect: nativeMode };
   }
   if (active.mode === "video") {
-    const mode = catalogue?.video_modes.find(
-      (candidate) => candidate.id === nativeMode,
-    );
-    return mode
+    const template = videoCatalogueTemplate(catalogue, nativeMode);
+    return template
       ? {
           kind: "native-profile",
           section: "video",
-          mode: mode.id,
-          label: mode.label,
+          mode: template.content.mode,
+          label: template.label,
         }
       : { kind: "root" };
   }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,7 +6,7 @@ export interface JsonObject {
 }
 
 export type CapabilityState = "supported" | "unsupported" | "evidence_gap";
-export type ModelSku = "H617A" | "H617E" | "H6199";
+export type ModelSku = string;
 export type ObservationConfidence =
   | "exact_session"
   | "activation_match"
@@ -178,8 +178,8 @@ export interface RelativeBrightness {
 
 export interface VideoProfileContent {
   kind: "video_profile";
-  model: "H6199";
-  mode: "movie" | "game";
+  model: ModelSku;
+  mode: string;
   full_screen: boolean;
   saturation: number;
   sound_effects: boolean;
@@ -350,7 +350,7 @@ export interface ModelEffectCatalogue {
 
 export interface EffectStudioCatalogue extends ModelEffectCatalogue {
   schema_version: 8;
-  sku: "H617A";
+  sku: ModelSku;
   models: Record<ModelSku, ModelEffectCatalogue>;
 }
 

--- a/frontend/src/validation-constants.ts
+++ b/frontend/src/validation-constants.ts
@@ -1,5 +1,3 @@
-import type { ModelSku } from "./types";
-
 export const CUSTOM_CATALOGUE_SCHEMA_VERSION = 8;
 export const MAX_EFFECT_NAME_LENGTH = 128;
 export const MAX_EFFECT_DOCUMENT_BYTES = 65_536;
@@ -16,14 +14,4 @@ export const PALETTE_CONFIG_RESERVED_MASK = 0x08;
 export const SCENE_TRAILING_PADDING_MAX = 0xff * 17;
 export const MOVEMENT_UNKNOWN_FLAGS_MASK = 0xe8;
 export const LAYER_UNKNOWN_FLAGS_MASK = 0xfd;
-export const MODEL_SKUS = ["H617A", "H617E", "H6199"] as const satisfies readonly ModelSku[];
 export const LEGACY_CUSTOM_CATALOGUE_SKU = "H617A" as const;
-export const VIDEO_MODE_IDS = ["movie", "game"] as const;
-
-export function isModelSku(model: string | undefined): model is ModelSku {
-  return MODEL_SKUS.includes(model as ModelSku);
-}
-
-export function isH617xModel(model: string | undefined): model is "H617A" | "H617E" {
-  return model === "H617A" || model === "H617E";
-}

--- a/frontend/src/validation.ts
+++ b/frontend/src/validation.ts
@@ -12,7 +12,6 @@ import type {
   LayeredSceneContent,
   LibraryItem,
   LibrarySnapshot,
-  ModelSku,
   MusicProfileContent,
   PaletteSceneContent,
   PaletteDiyEffectContent,
@@ -67,11 +66,9 @@ import {
   MAX_SCENE_CATALOGUE_ENTRIES,
   MAX_TIMESTAMP_LENGTH,
   MAX_USER_STATE_NAVIGATION_BYTES,
-  MODEL_SKUS,
   MOVEMENT_UNKNOWN_FLAGS_MASK,
   PALETTE_CONFIG_RESERVED_MASK,
   SCENE_TRAILING_PADDING_MAX,
-  VIDEO_MODE_IDS,
 } from "./validation-constants";
 
 const VERIFICATION_CONFIDENCE = [
@@ -447,7 +444,11 @@ export function decodeLibrarySnapshot(value: unknown): LibrarySnapshot {
       const model =
         summary.model === undefined
           ? undefined
-          : knownModelSku(summary.model);
+          : boundedString(
+              summary.model,
+              `library items[${index}].model`,
+              MAX_IDENTIFIER_LENGTH,
+            );
       return {
         id: boundedString(summary.id, "library item ID", MAX_IDENTIFIER_LENGTH),
         version: revisionValue(summary.version, "library item version", 1),
@@ -847,11 +848,11 @@ export function decodeEffectContent(value: unknown): EffectContent {
     case "palette_diy":
       return {
         kind,
-        model: enumString(
+        model: boundedString(
           content.model,
-          MODEL_SKUS,
           "palette DIY model",
-        ) as ModelSku,
+          MAX_IDENTIFIER_LENGTH,
+        ),
         family: integerValue(content.family, "palette DIY family", 0, 255),
         variant: integerValue(content.variant, "palette DIY variant", 0, 255),
         speed: integerValue(content.speed, "palette DIY speed", 0, 100),
@@ -860,11 +861,11 @@ export function decodeEffectContent(value: unknown): EffectContent {
     case "music_profile":
       return {
         kind,
-        model: enumString(
+        model: boundedString(
           content.model,
-          MODEL_SKUS,
           "music profile model",
-        ) as ModelSku,
+          MAX_IDENTIFIER_LENGTH,
+        ),
         mode: boundedString(
           content.mode,
           "music profile mode",
@@ -886,8 +887,16 @@ export function decodeEffectContent(value: unknown): EffectContent {
     case "video_profile":
       return {
         kind,
-        model: enumString(content.model, ["H6199"], "video profile model"),
-        mode: enumString(content.mode, VIDEO_MODE_IDS, "video profile mode"),
+        model: boundedString(
+          content.model,
+          "video profile model",
+          MAX_IDENTIFIER_LENGTH,
+        ),
+        mode: boundedString(
+          content.mode,
+          "video profile mode",
+          MAX_IDENTIFIER_LENGTH,
+        ),
         full_screen: booleanValue(
           content.full_screen,
           "video profile full-screen flag",
@@ -932,11 +941,11 @@ export function decodeEffectContent(value: unknown): EffectContent {
       const effect = objectValue(content.effect, "Workshop effect");
       return {
         kind,
-        model: enumString(
+        model: boundedString(
           content.model,
-          MODEL_SKUS,
           "Workshop model",
-        ) as ModelSku,
+          MAX_IDENTIFIER_LENGTH,
+        ),
         template: boundedString(
           content.template,
           "Workshop template",
@@ -1412,12 +1421,6 @@ function timestampString(value: unknown, name: string): string {
     invalid(`${name} must be an ISO 8601 timestamp with a UTC offset`);
   }
   return timestamp;
-}
-
-function knownModelSku(value: unknown): ModelSku | undefined {
-  return typeof value === "string" && MODEL_SKUS.includes(value as ModelSku)
-    ? (value as ModelSku)
-    : undefined;
 }
 
 function revisionValue(

--- a/frontend/src/video-profile-editor.ts
+++ b/frontend/src/video-profile-editor.ts
@@ -88,7 +88,7 @@ export class GoveeVideoProfileEditor extends LitElement {
         <section class="card empty-state" role="status">
           <h3 class="section-title">Video profile unavailable</h3>
           <p class="muted">
-            Load an H6199 video profile to edit video-sync settings.
+            Load a video profile to edit video-sync settings.
           </p>
         </section>
       `;

--- a/frontend/tests/fixtures/backend-contracts.json
+++ b/frontend/tests/fixtures/backend-contracts.json
@@ -3393,7 +3393,7 @@
           "single": "supported",
           "workshop": "supported"
         },
-        "display_name": "H617A/H617E LED Strip",
+        "display_name": "H617A LED Strip",
         "effect_categories": [
           "scenes",
           "effects",
@@ -3431,7 +3431,7 @@
           "single": "supported",
           "workshop": "supported"
         },
-        "display_name": "H617A/H617E LED Strip",
+        "display_name": "H617E LED Strip",
         "effect_categories": [
           "scenes",
           "effects",
@@ -3675,54 +3675,55 @@
       "H617E": {
         "categories": [
           {
-            "id": 129,
+            "id": 2522,
+            "name": "House of the Dragon"
+          },
+          {
+            "id": 5,
             "name": "Natural"
           },
           {
-            "id": 133,
+            "id": 6,
             "name": "Festival"
           }
         ],
         "enabled": true,
         "scenes": [
           {
+            "category": "House of the Dragon",
+            "category_id": 2522,
+            "display_name": "Dracarys",
+            "effect_id": 41599,
+            "name": "Dracarys",
+            "parameter_kind": "layers",
+            "scene_id": 29884,
+            "scene_type": 2,
+            "speed": null,
+            "variant": ""
+          },
+          {
             "category": "Natural",
-            "category_id": 129,
+            "category_id": 5,
             "display_name": "Sunrise",
-            "effect_id": 1073,
+            "effect_id": 110,
             "name": "Sunrise",
             "parameter_kind": "none",
-            "scene_id": 1011,
+            "scene_id": 128,
             "scene_type": 0,
             "speed": null,
             "variant": ""
           },
           {
-            "category": "Natural",
-            "category_id": 129,
-            "display_name": "Forest",
-            "effect_id": 11836,
-            "name": "Forest",
-            "parameter_kind": "layers",
-            "scene_id": 1013,
-            "scene_type": 2,
-            "speed": {
-              "default_index": 3,
-              "option_count": 4
-            },
-            "variant": ""
-          },
-          {
             "category": "Festival",
-            "category_id": 133,
-            "display_name": "Halloween",
-            "effect_id": 1103,
+            "category_id": 6,
+            "display_name": "Halloween-A",
+            "effect_id": 133,
             "name": "Halloween",
             "parameter_kind": "palette",
-            "scene_id": 1041,
+            "scene_id": 151,
             "scene_type": 1,
             "speed": null,
-            "variant": ""
+            "variant": "A"
           }
         ],
         "schema_version": 1,

--- a/frontend/tests/unit/backend-contracts.spec.ts
+++ b/frontend/tests/unit/backend-contracts.spec.ts
@@ -321,10 +321,31 @@ describe("focused response mutations", () => {
     expect(isCompatibleEditorInfo(decodeEditorApiInfo(payload))).toBe(false);
   });
 
-  test("unknown library models remain optional compatibility hints", () => {
+  test("future library models remain bounded compatibility hints", () => {
     const payload = cloneObject(responses.library_snapshot);
     objectArray(payload.items)[0].model = "future-model";
-    expect(decodeLibrarySnapshot(payload).items[0]).not.toHaveProperty("model");
+    expect(decodeLibrarySnapshot(payload).items[0].model).toBe("future-model");
+
+    objectArray(payload.items)[0].model = "x".repeat(256);
+    expect(() => decodeLibrarySnapshot(payload)).toThrow(
+      "library items[0].model must contain 1 to 255 characters",
+    );
+  });
+
+  test("profile models and video modes accept bounded future identifiers", () => {
+    const payload = cloneObject(contentSamples.video_profile);
+    payload.model = "H7000";
+    payload.mode = "cinema";
+    expect(decodeEffectContent(payload)).toMatchObject({
+      kind: "video_profile",
+      model: "H7000",
+      mode: "cinema",
+    });
+
+    payload.model = "x".repeat(256);
+    expect(() => decodeEffectContent(payload)).toThrow(
+      "video profile model must contain 1 to 255 characters",
+    );
   });
 
   test("library snapshots reject duplicate IDs and malformed item collections", () => {

--- a/frontend/tests/unit/catalogue-validation.spec.ts
+++ b/frontend/tests/unit/catalogue-validation.spec.ts
@@ -37,19 +37,41 @@ test("catalogue families require variations and the single-layer category", () =
   );
 });
 
-test("model catalogues require every release workflow", () => {
+test("release workflows remain bounded and unique without model-specific lists", () => {
   const payload = structuredClone(
     backendContracts.responses.custom_catalogue,
   );
-  payload.models.H6199.workflows = payload.models.H6199.workflows.filter(
-    (workflow) => workflow.id !== "workshop",
+  payload.models.H6199.workflows.push(
+    structuredClone(payload.models.H6199.workflows[0]),
   );
   expect(() => decodeCatalogue(payload)).toThrow(
-    "release workflows does not match H6199",
+    "release workflows IDs must be unique",
   );
 });
 
-test("catalogue keys and embedded template models must agree", () => {
+test("catalogue model keys are dynamic and embedded models must agree", () => {
+  const futureModel = structuredClone(
+    backendContracts.responses.custom_catalogue.models.H6199,
+  ) as unknown as {
+    sku: string;
+    templates: Array<{ content: Record<string, unknown> }>;
+    workshop_templates: Array<{ content: { model: string } }>;
+  };
+  futureModel.sku = "H7000";
+  for (const template of futureModel.templates) {
+    if ("model" in template.content) {
+      template.content.model = "H7000";
+    }
+  }
+  for (const template of futureModel.workshop_templates) {
+    template.content.model = "H7000";
+  }
+  const futurePayload = structuredClone(
+    backendContracts.responses.custom_catalogue,
+  );
+  (futurePayload.models as Record<string, unknown>).H7000 = futureModel;
+  expect(decodeCatalogue(futurePayload).models.H7000.sku).toBe("H7000");
+
   const wrongSku = structuredClone(
     backendContracts.responses.custom_catalogue,
   );
@@ -78,5 +100,15 @@ test("catalogue keys and embedded template models must agree", () => {
   ).workshop_templates = workshopTemplates;
   expect(() => decodeCatalogue(wrongTemplateModel)).toThrow(
     "content does not target H617A",
+  );
+
+  const invalidKey = structuredClone(
+    backendContracts.responses.custom_catalogue,
+  );
+  (invalidKey.models as Record<string, unknown>)["x".repeat(256)] = structuredClone(
+    invalidKey.models.H6199,
+  );
+  expect(() => decodeCatalogue(invalidKey)).toThrow(
+    "catalogue model key must contain 1 to 255 characters",
   );
 });

--- a/frontend/tests/unit/custom-effect-workflow.spec.ts
+++ b/frontend/tests/unit/custom-effect-workflow.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 
 import {
   buildCustomEffectEntries,
+  customEffectKindAvailable,
   libraryItemAvailable,
   type CustomEffectListContext,
 } from "../../src/custom-effect-list";
@@ -70,6 +71,17 @@ function context(items: LibrarySummary[] = []): CustomEffectListContext {
   };
 }
 
+test("effect kinds remain unavailable without a model catalogue", () => {
+  const unavailable = {
+    model: "H7000",
+    catalogue: undefined,
+    libraryItems: [],
+  };
+
+  expect(customEffectKindAvailable(unavailable, "h617a_multi")).toBe(false);
+  expect(customEffectKindAvailable(unavailable, "advanced")).toBe(false);
+});
+
 test("starter lists expose product choices but not protocol evidence fixtures", () => {
   expect(
     buildCustomEffectEntries(context(), "single-layer").map(
@@ -97,16 +109,16 @@ test("saved effects remain available in their content category", () => {
   ]);
 });
 
-test("H617E devices retain H617x effects summarised with the legacy model", () => {
-  const h617eContext: CustomEffectListContext = {
-    model: "H617E",
-    catalogue: { ...catalogue, sku: "H617E" },
+test("content-kind capabilities allow model-independent protocol effects", () => {
+  const futureContext: CustomEffectListContext = {
+    model: "H7000",
+    catalogue: { ...catalogue, sku: "H7000" },
     libraryItems: [saved],
   };
 
-  expect(libraryItemAvailable(h617eContext, saved)).toBe(true);
+  expect(libraryItemAvailable(futureContext, saved)).toBe(true);
   expect(
-    libraryItemAvailable(h617eContext, {
+    libraryItemAvailable(futureContext, {
       ...saved,
       kind: "music_profile",
     }),

--- a/frontend/tests/unit/effect-editor-model.spec.ts
+++ b/frontend/tests/unit/effect-editor-model.spec.ts
@@ -239,8 +239,22 @@ test("library summaries retain model metadata and stable ordering", () => {
   expect(summaries[0].model).toBe("H617A");
   expect(isEditableEffectContent(item.content)).toBe(true);
   expect(customEffectCategoryForKind(item.content.kind)).toBe("single-layer");
-  expect(libraryKindPriority("palette_diy", "H6199")).toBeLessThan(
-    libraryKindPriority("advanced", "H6199"),
+  const paletteCatalogue = {
+    ...catalogue,
+    apply: {
+      ...catalogue.apply,
+      single: "unsupported",
+      palette_diy: "supported",
+    },
+  } satisfies ModelEffectCatalogue;
+  expect(libraryKindPriority("palette_diy", paletteCatalogue)).toBeLessThan(
+    libraryKindPriority("workshop", paletteCatalogue),
+  );
+  expect(libraryKindPriority("workshop", paletteCatalogue)).toBeLessThan(
+    libraryKindPriority("music_profile", paletteCatalogue),
+  );
+  expect(libraryKindPriority("music_profile", catalogue)).toBeLessThan(
+    libraryKindPriority("workshop", catalogue),
   );
 });
 

--- a/frontend/tests/unit/panel-model.spec.ts
+++ b/frontend/tests/unit/panel-model.spec.ts
@@ -16,7 +16,6 @@ import {
 } from "../../src/studio-navigation";
 import {
   blankPainted,
-  blankVideoProfile,
   serialiseEditable,
 } from "../../src/effect-editor-model";
 import { blankAdvancedContent } from "../../src/advanced-effect-model";
@@ -32,6 +31,7 @@ import type {
   MusicProfileContent,
   PaintedContent,
   PaletteDiyEffectContent,
+  VideoProfileContent,
 } from "../../src/types";
 
 function device(
@@ -92,13 +92,36 @@ function painted(): PaintedContent {
   };
 }
 
+function videoProfile(
+  model: ModelSku,
+  mode: string,
+): VideoProfileContent {
+  return {
+    kind: "video_profile",
+    model,
+    mode,
+    full_screen: true,
+    saturation: 50,
+    sound_effects: false,
+    sound_effects_softness: 50,
+    white_balance_position: 17,
+    relative_brightness: {
+      left: 100,
+      top: 100,
+      right: 100,
+      bottom: 100,
+    },
+    blank_screen: false,
+  };
+}
+
 function templateDefaultDetail(
   templateId: string,
   model: ModelSku = "H6199",
 ): CatalogueTemplateDefaultDetail {
   const content =
     templateId.startsWith("template:video:")
-      ? blankVideoProfile(templateId.endsWith(":game") ? "game" : "movie")
+      ? videoProfile(model, templateId.endsWith(":game") ? "game" : "movie")
       : templateId.startsWith("template:music:")
         ? {
             kind: "music_profile" as const,
@@ -150,6 +173,20 @@ function h6199Catalogue(): ModelEffectCatalogue {
       { id: "movie", label: "Movie" },
       { id: "game", label: "Game" },
     ],
+    templates: [
+      {
+        id: "template:video:movie",
+        label: "Movie",
+        category: "video",
+        content: videoProfile("H6199", "movie"),
+      },
+      {
+        id: "template:video:game",
+        label: "Game",
+        category: "video",
+        content: videoProfile("H6199", "game"),
+      },
+    ],
     workshop_templates: [],
     workflows: [],
     supports: {
@@ -184,6 +221,30 @@ function installH6199Catalogue(model: PanelModel): void {
       H617A: { ...catalogue, sku: "H617A" },
       H617E: { ...catalogue, sku: "H617E" },
       H6199: catalogue,
+    },
+  } as CustomEffectCatalogue;
+}
+
+function installFutureCatalogue(
+  model: PanelModel,
+  sku: ModelSku,
+  musicSensitivityMaximum: number,
+): void {
+  const catalogue = structuredClone(h6199Catalogue());
+  catalogue.sku = sku;
+  catalogue.limits.music_sensitivity_max = musicSensitivityMaximum;
+  for (const template of catalogue.templates ?? []) {
+    if ("model" in template.content) {
+      template.content.model = sku;
+    }
+  }
+  model.customCatalogue = {
+    ...catalogue,
+    schema_version: 8,
+    sku: "H617A",
+    models: {
+      H617A: { ...catalogue, sku: "H617A" },
+      [sku]: catalogue,
     },
   } as CustomEffectCatalogue;
 }
@@ -746,6 +807,7 @@ test("pending transitions save named new drafts directly", async () => {
   model.devices = [device("entry-a", "H617A")];
   model.devices[0].custom_effects.advanced = "supported";
   model.selectedDeviceId = "entry-a";
+  installH6199Catalogue(model);
   const { controller, editorController } = panelControllerHarness(model);
 
   editorController.newEffect("advanced");
@@ -971,6 +1033,7 @@ test("busy pending-transition saves ignore cancellation until persistence finish
   model.devices = [device("entry-a", "H617A")];
   model.devices[0].custom_effects.advanced = "supported";
   model.selectedDeviceId = "entry-a";
+  installH6199Catalogue(model);
   const { controller, editorController, modal } =
     panelControllerHarness(model);
   editorController.newEffect("advanced");
@@ -1017,6 +1080,7 @@ test("pending-transition navigation preserves a standalone Live apply error", as
   selected.custom_effects.advanced = "supported";
   model.devices = [selected];
   model.selectedDeviceId = selected.config_entry_id;
+  installH6199Catalogue(model);
   const { controller, editorController } = panelControllerHarness(model);
   editorController.newEffect("advanced");
   model.name = "Named Advanced effect";
@@ -1363,6 +1427,7 @@ test("Reset restores a new effect name and blank content", () => {
   model.devices = [device("entry-a", "H617A")];
   model.devices[0].custom_effects.advanced = "supported";
   model.selectedDeviceId = "entry-a";
+  installH6199Catalogue(model);
   const controller = editor(model);
 
   controller.newEffect("advanced");
@@ -1392,6 +1457,7 @@ test("name-only Reset restores a new draft without scheduling preview", () => {
   model.devices = [device("entry-a", "H617A")];
   model.devices[0].custom_effects.advanced = "supported";
   model.selectedDeviceId = "entry-a";
+  installH6199Catalogue(model);
   const preview = new PanelPreviewController(model);
   const scheduleEdited = vi.spyOn(preview, "scheduleEdited");
   const modal = new PanelModalController(model, {
@@ -1422,6 +1488,7 @@ test("Advanced waits for New or a saved effect instead of opening a redundant st
   model.devices = [device("entry-a", "H617A")];
   model.devices[0].custom_effects.advanced = "supported";
   model.selectedDeviceId = "entry-a";
+  installH6199Catalogue(model);
   const controller = editor(model);
   const transitionEpoch = controller.beginTransition();
 
@@ -1438,6 +1505,7 @@ test("explicit New Reset restores its name while layered scene Reset retains its
   model.devices = [device("entry-a", "H617A")];
   model.devices[0].custom_effects.advanced = "supported";
   model.selectedDeviceId = "entry-a";
+  installH6199Catalogue(model);
   const controller = editor(model);
 
   controller.newEffect("advanced");
@@ -1548,6 +1616,37 @@ test("category transitions stay blank without a matching active item", async () 
   expect(model.name).toBe("");
   await controller.selectSection("video");
   expect(model.name).toBe("");
+});
+
+test("future model profile defaults come from catalogue limits and templates", () => {
+  const selected = device("entry-a", "H7000");
+  selected.profiles = { music: "supported", video: "supported" };
+  const model = new PanelModel(() => undefined);
+  model.isAdmin = true;
+  model.devices = [selected];
+  model.selectedDeviceId = selected.config_entry_id;
+  model.customEffectCategory = "music";
+  installFutureCatalogue(model, selected.model, 87);
+  const controller = editor(model);
+
+  controller.newCustomEffect("music");
+  expect(model.content).toMatchObject({
+    kind: "music_profile",
+    model: "H7000",
+    sensitivity: 87,
+  });
+
+  model.section = "video";
+  controller.openVideoTemplate("movie", "Movie", false);
+  expect(model.editorSource).toMatchObject({
+    kind: "catalogue",
+    selectionIdentity: "template:video:movie",
+  });
+  expect(model.content).toMatchObject({
+    kind: "video_profile",
+    model: "H7000",
+    mode: "movie",
+  });
 });
 
 test("automatic restoration selects only a matching fresh native category", async () => {
@@ -1994,6 +2093,7 @@ test("painted workspace restoration keeps variation content under the fixed Pain
     { id: "clockwise", label: "Clockwise" },
     { id: "twinkle", label: "Twinkle" },
   ];
+  model.customCatalogue!.models.H617A.apply.painted = "supported";
   const { controller } = panelControllerHarness(model);
 
   await controller.openInitialContext();
@@ -2880,7 +2980,7 @@ test("Save As keeps video profile copies in the Video section", async () => {
     version: 2,
     updated_at: "2026-08-18T00:00:00Z",
     name: "Cinema",
-    content: blankVideoProfile("movie"),
+    content: videoProfile("H6199", "movie"),
     content_hash: "video-hash",
     origin: { kind: "authored", source_id: null },
     extensions: {},
@@ -3266,6 +3366,7 @@ test("automatic save flushes before navigation and exposes failures to the trans
   model.customCatalogue!.models.H617A.painted_effects = [
     { id: "cycle", label: "Cycle" },
   ];
+  model.customCatalogue!.models.H617A.apply.painted = "supported";
   const { controller, editorController, modal } = panelControllerHarness(model);
   const saved = item(painted());
   editorController.applyLibraryItem(saved);
@@ -3383,6 +3484,7 @@ test("Live-off No discards local saved edits and reopens the clean active item",
   model.customCatalogue!.models.H617A.painted_effects = [
     { id: "cycle", label: "Cycle" },
   ];
+  model.customCatalogue!.models.H617A.apply.painted = "supported";
   const { controller, editorController } = panelControllerHarness(model);
   editorController.applyLibraryItem(saved);
   editorController.updatePaintedContent({ speed: 92 }, "committed");
@@ -3449,6 +3551,7 @@ test("device, item, scene, and New transitions share the pre-mutation guard", as
   model.customCatalogue!.models.H617A.painted_effects = [
     { id: "cycle", label: "Cycle" },
   ];
+  model.customCatalogue!.models.H617A.apply.painted = "supported";
   const { controller, editorController } = panelControllerHarness(model);
   const saved = item(painted());
   editorController.applyLibraryItem(saved);
@@ -3499,7 +3602,7 @@ test("video template selection is guarded and restores focus on Cancel", async (
       .mockImplementation(async (_deviceId: string, templateId: string) =>
         templateDefaultDetail(templateId, "H6199")),
   } as unknown as EffectStudioApi;
-  const content = blankVideoProfile("movie");
+  const content = videoProfile("H6199", "movie");
   const saved: LibraryItem = {
     schema_version: 1,
     id: "saved-video",
@@ -3523,7 +3626,7 @@ test("video template selection is guarded and restores focus on Cancel", async (
   } as unknown as HTMLElement;
   const epoch = model.editorTransitionEpoch;
 
-  await controller.selectVideoTemplate("game", "Game", returnFocus);
+  await controller.selectVideoTemplate("template:video:game", "Game", returnFocus);
 
   expect(model.pendingTransitionDialog?.primaryLabel).toBe("Save");
   expect(model.editorTransitionEpoch).toBe(epoch);
@@ -3537,7 +3640,7 @@ test("video template selection is guarded and restores focus on Cancel", async (
   await Promise.resolve();
   expect(focus).toHaveBeenCalledOnce();
 
-  await controller.selectVideoTemplate("game", "Game", returnFocus);
+  await controller.selectVideoTemplate("template:video:game", "Game", returnFocus);
   await controller.declinePendingTransition();
   expect(model.editorSource.kind).toBe("catalogue");
   expect(model.templateSelection).toBe("template:video:game");

--- a/frontend/tests/unit/studio-navigation.spec.ts
+++ b/frontend/tests/unit/studio-navigation.spec.ts
@@ -62,6 +62,30 @@ const catalogue: ModelEffectCatalogue = {
   effects: [],
   music_modes: [{ id: "separation", label: "Separation" }],
   video_modes: [{ id: "movie", label: "Movie" }],
+  templates: [
+    {
+      id: "template:video:movie",
+      label: "Movie",
+      category: "video",
+      content: {
+        kind: "video_profile",
+        model: "H617A",
+        mode: "movie",
+        full_screen: true,
+        saturation: 50,
+        sound_effects: false,
+        sound_effects_softness: 50,
+        white_balance_position: 17,
+        relative_brightness: {
+          left: 100,
+          top: 100,
+          right: 100,
+          bottom: 100,
+        },
+        blank_screen: false,
+      },
+    },
+  ],
   workshop_templates: [],
   workflows: [],
   supports: {

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,3 +1,5 @@
+import pytest
+
 from custom_components.ha_govee_led_ble.const import (
     CONF_ALWAYS_INCLUDE_CUSTOM_EFFECTS,
     CONF_EFFECT_FAMILIES,
@@ -5,6 +7,8 @@ from custom_components.ha_govee_led_ble.const import (
     MODEL_PROFILES,
     UNSUPPORTED_PROFILE,
     ModelProfile,
+    ReadDomain,
+    SupportQuality,
     always_include_custom_effects_from_options,
     default_effect_families,
     effect_families_from_options,
@@ -19,6 +23,8 @@ from custom_components.ha_govee_led_ble.const import (
 def test_segment_count_and_supports_segments():
     assert MODEL_PROFILES["H617A"].segment_count == 15
     assert MODEL_PROFILES["H6199"].segment_count == 15
+    assert MODEL_PROFILES["H617A"].segment_group_count == 5
+    assert MODEL_PROFILES["H6199"].segment_group_count == 4
     assert MODEL_PROFILES["H617A"].supports_segments
     # Both models paint segments. The H6199 was gated off until captured app writes on it were
     # reproduced byte for byte, whole-strip and per-segment, including the union frame that proves
@@ -31,17 +37,22 @@ def test_supports_segments_defaults_false():
     assert not ModelProfile("x").supports_segments
 
 
-def test_h617a_and_h617e_share_complete_feature_profile():
-    profile = MODEL_PROFILES["H617A"]
-    assert MODEL_PROFILES["H617E"] is profile
-    assert profile.supports_scenes
-    assert profile.supports_music_mode
-    assert len(profile.music_modes) == 11
-    assert profile.segment_count == 15
-    assert profile.supports_segments
-    assert profile.supports_advanced_effects
-    assert profile.supports_multi_layered_effects
-    assert profile.connection_idle_timeout == 3.0
+def test_h617a_and_h617e_share_wire_behaviour_but_keep_exact_product_profiles():
+    h617a = MODEL_PROFILES["H617A"]
+    h617e = MODEL_PROFILES["H617E"]
+    assert h617e is not h617a
+    assert h617e.name == "H617E LED Strip"
+    assert h617e.support_quality is SupportQuality.COMPATIBLE
+    assert h617e.scene_catalogue_sku == "H617E"
+    assert h617e.read_domains == h617a.read_domains
+    assert h617e.supports_scenes
+    assert h617e.supports_music_mode
+    assert len(h617e.music_modes) == 11
+    assert h617e.segment_count == 15
+    assert h617e.supports_segments
+    assert h617e.supports_advanced_effects
+    assert h617e.supports_multi_layered_effects
+    assert h617e.connection_idle_timeout == 3.0
     assert resolve_model("H617E") == "H617E"
     assert protocol_model("H617E") == "H617A"
     assert wire_model("H617E") == "H617A"
@@ -49,7 +60,15 @@ def test_h617a_and_h617e_share_complete_feature_profile():
 
 def test_h6076_profile_is_basic_and_fail_closed():
     profile = MODEL_PROFILES["H6076"]
+    assert profile.support_quality is SupportQuality.PARTIAL
     assert profile.state_readable
+    assert profile.read_domains == {
+        ReadDomain.POWER,
+        ReadDomain.BRIGHTNESS,
+        ReadDomain.FIRMWARE,
+        ReadDomain.HARDWARE,
+    }
+    assert profile.setup_required_read_domains == {ReadDomain.POWER, ReadDomain.BRIGHTNESS}
     assert profile.supports_rgb and profile.supports_color_temperature
     assert (profile.min_color_temp_kelvin, profile.max_color_temp_kelvin) == (2700, 6500)
     assert not profile.supports_color_mode_readback
@@ -60,6 +79,11 @@ def test_h6076_profile_is_basic_and_fail_closed():
     assert profile.whole_device_mask == 0x007F
     assert wire_model("H6076") == "H617A"
     assert protocol_model("H6076") == "H6076"
+
+
+def test_setup_required_domains_must_be_readable():
+    with pytest.raises(ValueError, match="setup-required"):
+        ModelProfile("x", setup_required_read_domains=frozenset({ReadDomain.POWER}))
 
 
 def test_unknown_models_fail_closed():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -18,7 +18,7 @@ from custom_components.ha_govee_led_ble.ble_device_resolver import (
     BLEDeviceResolution,
     BLEDeviceResolver,
 )
-from custom_components.ha_govee_led_ble.const import DOMAIN, MODEL_PROFILES, MUSIC_MODE_SLUGS
+from custom_components.ha_govee_led_ble.const import DOMAIN, MODEL_PROFILES, MUSIC_MODE_SLUGS, ReadDomain
 from custom_components.ha_govee_led_ble.control_arbiter import BLEControlArbiter, ControlIntent
 from custom_components.ha_govee_led_ble.coordinator import (
     IDENTITY_RETRY_TICKS,
@@ -127,7 +127,8 @@ def h6199(hass):
 def limited_readback_coord(hass):
     profile = replace(
         MODEL_PROFILES["H617A"],
-        supports_color_mode_readback=False,
+        read_domains=MODEL_PROFILES["H617A"].read_domains - {ReadDomain.COLOUR_MODE, ReadDomain.SEGMENTS},
+        setup_required_read_domains=frozenset({ReadDomain.POWER, ReadDomain.BRIGHTNESS}),
         segment_count=0,
         supports_segment_writes=False,
     )
@@ -316,7 +317,7 @@ async def test_restore_effect_control_state_reapplies_model_scene(coord, h6199):
 
         assert recovered is True
         assert send.await_args_list == [call(packet) for packet in expected]
-        refresh.assert_awaited_once_with(expected_effect=effect)
+        refresh.assert_awaited_once_with(expected_scene_code=scene.code)
         assert coordinator.active_mode == "scene"
 
 
@@ -507,9 +508,93 @@ async def test_restore_effect_control_state_reapplies_h6199_scene(h6199):
 
     assert recovered is True
     assert send.await_args_list == [call(packet) for packet in build_native_scene_packets("H6199", scene)]
-    refresh.assert_awaited_once_with(expected_effect="forest")
+    refresh.assert_awaited_once_with(expected_scene_code=scene.code)
     assert h6199.effect == "forest"
     assert (h6199.diy_code, h6199.music_mode, h6199.video_mode) == (None, "off", "off")
+
+
+async def test_restore_effect_control_state_maps_h617e_legacy_scene_name(hass):
+    coordinator = GoveeBLECoordinator(
+        hass,
+        "22:33:44:55:66:78",
+        "H617E",
+        configuration_url=_CONFIGURATION_URL,
+    )
+    state = PriorControlState(
+        mode="scene",
+        is_on=True,
+        brightness_pct=72,
+        rgb_color=(1, 2, 3),
+        effect="aurora",
+    )
+    scene = MODEL_SCENES["H617E"]["aurora-a"]
+
+    with (
+        patch.object(coordinator, "send_command", new_callable=AsyncMock) as send,
+        patch.object(coordinator, "refresh_state", new_callable=AsyncMock, return_value=True) as refresh,
+    ):
+        assert await coordinator.async_restore_effect_control_state(state, overwritten_diy_code=None)
+
+    assert send.await_args_list == [call(packet) for packet in build_native_scene_packets("H617E", scene)]
+    refresh.assert_awaited_once_with(expected_scene_code=scene.code)
+    assert coordinator.effect == "aurora-a"
+
+
+async def test_restore_effect_control_state_preserves_h617e_raw_legacy_scene(hass):
+    coordinator = GoveeBLECoordinator(
+        hass,
+        "22:33:44:55:66:79",
+        "H617E",
+        configuration_url=_CONFIGURATION_URL,
+    )
+    exact_codes = {scene.code for scene in MODEL_SCENES["H617E"].values()}
+    legacy_name, legacy = next(
+        (name, scene) for name, scene in MODEL_SCENES["H617A"].items() if scene.code not in exact_codes
+    )
+    coordinator.is_on = True
+    coordinator.color_mode = ParsedMode.SCENE
+    coordinator._scene_code = legacy.code
+    coordinator.effect = None
+    state = coordinator.capture_effect_control_state()
+
+    assert state.mode == "scene"
+    assert state.scene_code == legacy.code
+    with (
+        patch.object(coordinator, "send_command", new_callable=AsyncMock) as send,
+        patch.object(coordinator, "refresh_state", new_callable=AsyncMock, return_value=True) as refresh,
+    ):
+        assert await coordinator.async_restore_effect_control_state(state, overwritten_diy_code=None)
+
+    assert send.await_args_list == [call(packet) for packet in build_native_scene_packets("H617E", legacy)]
+    refresh.assert_awaited_once_with(expected_scene_code=legacy.code)
+    assert coordinator.effect == legacy_name
+
+
+async def test_restore_effect_control_state_uses_legacy_identity_to_disambiguate_scene_code(hass):
+    coordinator = GoveeBLECoordinator(
+        hass,
+        "22:33:44:55:66:80",
+        "H617E",
+        configuration_url=_CONFIGURATION_URL,
+    )
+    legacy = MODEL_SCENES["H617A"]["aurora"]
+    state = PriorControlState(
+        mode="scene",
+        is_on=True,
+        brightness_pct=72,
+        rgb_color=(1, 2, 3),
+        effect="aurora",
+        scene_code=legacy.code,
+    )
+
+    with (
+        patch.object(coordinator, "send_command", new_callable=AsyncMock) as send,
+        patch.object(coordinator, "refresh_state", new_callable=AsyncMock, return_value=True),
+    ):
+        assert await coordinator.async_restore_effect_control_state(state, overwritten_diy_code=None)
+
+    assert send.await_args_list == [call(packet) for packet in build_native_scene_packets("H617E", legacy)]
+    assert coordinator.effect == "aurora"
 
 
 async def test_send_command(coord):
@@ -1388,6 +1473,52 @@ async def test_refresh_state_query_selection(coord):
         sq.assert_awaited_with(query_power=True, query_brightness=False, query_color_mode=True)
 
 
+async def test_h617e_legacy_scene_verifies_by_raw_selector_code(hass):
+    coordinator = GoveeBLECoordinator(
+        hass,
+        "33:44:55:66:77:89",
+        "H617E",
+        configuration_url=_CONFIGURATION_URL,
+    )
+    coordinator._client = client = _c()
+    exact_codes = {scene.code for scene in MODEL_SCENES["H617E"].values()}
+    legacy = next(scene for scene in MODEL_SCENES["H617A"].values() if scene.code not in exact_codes)
+
+    async def _reply(**_kwargs) -> bool:
+        coordinator._notify_callback(
+            None,
+            bytearray(proto.build_packet(0xAA, 0x05, [0x04, legacy.code & 0xFF, legacy.code >> 8])),
+        )
+        return True
+
+    with (
+        patch.object(coordinator, "_ensure_connected", new=AsyncMock(return_value=client)),
+        patch.object(coordinator, "_send_state_queries", new=AsyncMock(side_effect=_reply)),
+    ):
+        assert await coordinator.refresh_state(expected_scene_code=legacy.code, timeout=0.02)
+
+    assert coordinator.scene_code == legacy.code
+    assert coordinator.unknown_scene_code == legacy.code
+
+
+async def test_refresh_all_can_require_only_the_setup_domains(coord):
+    coord._client = client = _c()
+
+    async def _reply(**_kwargs) -> bool:
+        coord._notify_callback(None, bytearray(proto.build_packet(0xAA, 0x01, [1])))
+        return True
+
+    with (
+        patch.object(coord, "_ensure_connected", new=AsyncMock(return_value=client)),
+        patch.object(coord, "_send_state_queries", new=AsyncMock(side_effect=_reply)),
+    ):
+        assert await coord.refresh_state(
+            refresh_all=True,
+            required_domains=frozenset({ReadDomain.POWER}),
+            timeout=0.02,
+        )
+
+
 async def test_refresh_without_colour_readback_requires_power_and_brightness_only(limited_readback_coord):
     limited_readback_coord._client = client = _c()
     limited_readback_coord.rgb_color = (12, 34, 56)
@@ -1453,6 +1584,10 @@ async def test_h6076_refresh_all_uses_limited_readback_profile(hass):
     ):
         assert await coordinator.refresh_state(refresh_all=True, timeout=0.02)
 
+    assert coordinator.scene_name_set == frozenset()
+    with pytest.raises(ValueError, match="does not support native scenes"):
+        await coordinator.async_apply_native_scene(next(iter(MODEL_SCENES["H6076"])))
+
 
 async def test_refresh_reply_timeout_starts_after_connection(coord):
     client = _c(disconnect=AsyncMock())
@@ -1512,6 +1647,14 @@ async def test_refresh_state_queries_each_display_domain(h6199):
         assert queries.await_args.kwargs["query_blank_screen"] is True
         queries.reset_mock()
         assert await h6199.refresh_state(expected_relative_brightness=(51, 20, 31, 41))
+        assert queries.await_args.kwargs["query_relative_brightness"] is True
+        queries.reset_mock()
+        assert await h6199.refresh_state(
+            refresh_all=True,
+            required_domains=frozenset({ReadDomain.DISPLAY_SETTING, ReadDomain.RELATIVE_BRIGHTNESS}),
+        )
+        assert queries.await_args.kwargs["query_white_balance"] is True
+        assert queries.await_args.kwargs["query_blank_screen"] is True
         assert queries.await_args.kwargs["query_relative_brightness"] is True
 
 
@@ -2038,12 +2181,13 @@ async def test_preview_observation_does_not_repeat_silent_query(coord):
         new=AsyncMock(side_effect=query_state),
     ) as query:
         result = await coord.async_preview_observe(
-            {"effect": "glacier"},
+            {"scene_code": SCENES["glacier"].code},
             timeout=0.05,
         )
 
     assert result is None
     assert query.await_count == 1
+    assert query.await_args.kwargs["query_color_mode"] is True
     assert not coord._control_lock.locked()
 
 
@@ -2336,7 +2480,11 @@ async def test_first_refresh_reports_update_failed_then_degrades_silently(coord)
 
 
 async def test_first_refresh_non_readable_requires_presence(hass):
-    flat = replace(MODEL_PROFILES["H617A"], state_readable=False)
+    flat = replace(
+        MODEL_PROFILES["H617A"],
+        read_domains=frozenset(),
+        setup_required_read_domains=frozenset(),
+    )
     with patch(f"{M}.get_profile", return_value=flat):
         c = GoveeBLECoordinator(
             hass,

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -11,6 +11,7 @@ from custom_components.ha_govee_led_ble.coordinator_status import (
     parse_color_mode,
 )
 from custom_components.ha_govee_led_ble.generated_protocol_adapter import ProtocolParseRejection
+from custom_components.ha_govee_led_ble.scenes import MODEL_SCENES
 from custom_components.ha_govee_led_ble.transport import xor_checksum
 
 H = bytes.fromhex
@@ -75,6 +76,20 @@ def test_h617a_colour_modes_preserve_scene_diy_and_music_semantics() -> None:
     assert rhythm.music_mode == "rhythm" and rhythm.music_sensitivity == 88 and rhythm.music_calm is True
     static = _parse_colour("aa051501000000000000000000000000000000bb")
     assert static.mode is ParsedMode.COLOUR and static.multi_effect_flag == 1
+
+
+def test_h617e_scene_readback_uses_its_exact_catalogue() -> None:
+    h617a_codes = {scene.code for scene in MODEL_SCENES["H617A"].values()}
+    name, scene = next((name, scene) for name, scene in MODEL_SCENES["H617E"].items() if scene.code not in h617a_codes)
+    frame = bytearray(20)
+    frame[:3] = bytes((0xAA, 0x05, 0x04))
+    frame[3:5] = scene.code.to_bytes(2, "little")
+    frame[-1] = xor_checksum(frame[:-1])
+    decoded = decode_status_frame(bytes(frame), "H617E")
+
+    assert decoded is not None
+    parsed = parse_color_mode(decoded.generated, "H617E")
+    assert parsed.effect == name
 
 
 def test_h6199_video_and_music_fields_decode() -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -44,6 +44,7 @@ async def test_surfaces_segment_fields(mock_h6199_coordinator):
     colors = [(10, 20, 30)] * 15
     diag = await _run(_prep(mock_h6199_coordinator, segment_colors=colors))
     coord = diag["coordinator"]
+    assert coord["support_quality"] == "supported"
     assert coord["supports_segments"] is True
     assert coord["segment_count"] == 15
     assert coord["segment_colors"] == colors
@@ -90,6 +91,9 @@ async def test_h6076_diagnostics_expose_basic_capability_boundary(mock_h6076_coo
     diag = await _run(_prep(mock_h6076_coordinator), entry)
     coord = diag["coordinator"]
 
+    assert coord["support_quality"] == "partial"
+    assert coord["read_domains"] == ["brightness", "firmware", "hardware", "power"]
+    assert coord["setup_required_read_domains"] == ["brightness", "power"]
     assert coord["supports_rgb"] is True
     assert coord["supports_color_temperature"] is True
     assert coord["color_temperature_range"] == {"minimum_kelvin": 2700, "maximum_kelvin": 6500}

--- a/tests/test_effect_catalogue.py
+++ b/tests/test_effect_catalogue.py
@@ -34,6 +34,7 @@ from custom_components.ha_govee_led_ble.effect_contracts import (
     PhysicalValidationState,
     VerificationConfidence,
     frontend_release_capabilities,
+    release_capabilities_for_model,
     release_capability,
     studio_apply_capability_state,
     workflow_capability_state,
@@ -68,6 +69,14 @@ def test_model_aware_catalogue_includes_supported_models_and_legacy_h617a_view()
         "palette_diy": "unsupported",
         "workshop": "supported",
     }
+
+
+def test_h617e_has_exact_release_capability_records():
+    h617a = release_capabilities_for_model("H617A")
+    h617e = release_capabilities_for_model("H617E")
+
+    assert {capability.workflow for capability in h617e} == {capability.workflow for capability in h617a}
+    assert all(capability.model == "H617E" for capability in h617e)
 
 
 def test_h617a_model_catalogue_preserves_type04_and_painted_contracts() -> None:

--- a/tests/test_effect_deployments.py
+++ b/tests/test_effect_deployments.py
@@ -429,6 +429,7 @@ def test_deployment_round_trip_preserves_prior_state_and_verification_confidence
         rgb_color=(1, 2, 3),
         color_temp_kelvin=4000,
         effect="forest",
+        scene_code=2163,
         diy_code=800,
         music_mode="separation",
         video_mode="game",
@@ -481,6 +482,7 @@ def test_deployment_round_trip_preserves_prior_state_and_verification_confidence
 @pytest.mark.parametrize(
     ("changes", "message"),
     [
+        ({"scene_code": -1}, "prior scene code must be from 0 to 65535"),
         ({"music_separation_point": 0}, "prior separation point must be from 1 to 5"),
         ({"music_separation_gradient": 1}, "prior separation gradient must be a boolean"),
         ({"music_fountain_direction": "sideways"}, "prior fountain direction is invalid"),

--- a/tests/test_effect_preview.py
+++ b/tests/test_effect_preview.py
@@ -172,7 +172,7 @@ async def test_worker_compiles_active_then_only_newest_pending_request(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    coordinator = _coordinator()
+    coordinator = _coordinator(readable=True)
     first_started = asyncio.Event()
     release_first = asyncio.Event()
     writes = 0
@@ -444,13 +444,14 @@ async def test_native_scene_preview_uses_scene_speed_primitive_for_repeated_sele
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    coordinator = _coordinator()
+    coordinator = _coordinator(readable=True)
     coordinator.effect_families = set()
     applied = []
 
     async def apply_scene(
         scene_name,
         *,
+        scene_entry,
         speed_index,
         canonical_body,
         before_write,
@@ -458,6 +459,7 @@ async def test_native_scene_preview_uses_scene_speed_primitive_for_repeated_sele
         intent,
     ):
         async with coordinator._control_lock:
+            assert scene_entry is scene
             applied.append((scene_name, speed_index, verify))
             await before_write()
             await coordinator.async_preview_write(b"scene")
@@ -485,6 +487,56 @@ async def test_native_scene_preview_uses_scene_speed_primitive_for_repeated_sele
 
     assert len(applied) == 2
     assert all(item[1:] == (scene.speed.default_index, False) for item in applied)
+    assert coordinator.async_preview_observe.await_args_list[-1].args[0] == {
+        "is_on": True,
+        "scene_code": scene.code,
+    }
+    await manager.async_shutdown()
+
+
+async def test_ambiguous_h617e_legacy_scene_preview_requires_code_and_canonical_label(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = _coordinator(model="H617E", readable=True)
+
+    async def apply_scene(
+        _scene_name,
+        *,
+        scene_entry,
+        speed_index,
+        canonical_body,
+        before_write,
+        verify,
+        intent,
+    ):
+        assert scene_entry.name == "Aurora"
+        await before_write()
+        await coordinator.async_preview_write(b"scene")
+
+    coordinator.async_apply_native_scene = AsyncMock(side_effect=apply_scene)
+    manager, _cache = await _manager(hass, monkeypatch, coordinator)
+    owner = object()
+    session_id = _open(manager, owner, [])
+    legacy = next(entry for entry in SCENE_ENTRIES["H617A"] if entry.name == "Aurora")
+
+    await manager.async_queue_scene(
+        session_id=session_id,
+        owner=owner,
+        config_entry_id="entry-a",
+        sequence=1,
+        updated_at="2026-08-17T00:00:01Z",
+        scene_id=legacy.scene_id,
+        effect_id=legacy.effect_id,
+        speed_index=legacy.speed.default_index if legacy.speed is not None else None,
+    )
+    await manager.async_wait_idle("entry-a")
+
+    assert coordinator.async_preview_observe.await_args.args[0] == {
+        "is_on": True,
+        "scene_code": legacy.code,
+        "effect": "aurora-a",
+    }
     await manager.async_shutdown()
 
 
@@ -679,7 +731,7 @@ async def test_scene_default_storage_failure_is_reported_after_transport(
     manager, _cache = await _manager(hass, monkeypatch, coordinator)
     monkeypatch.setattr(
         manager._scene_defaults,
-        "async_set",
+        "async_replace_identities",
         AsyncMock(side_effect=OSError("storage failed")),
     )
     owner = object()
@@ -722,12 +774,14 @@ async def test_selector_only_scene_preview_never_creates_a_default(
     async def apply_scene(
         _scene_name,
         *,
+        scene_entry,
         speed_index,
         canonical_body,
         before_write,
         verify,
         intent,
     ):
+        assert scene_entry is scene
         assert speed_index is None
         assert canonical_body is None
         assert verify is False

--- a/tests/test_effect_runtime.py
+++ b/tests/test_effect_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from hashlib import sha256
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call
@@ -28,6 +29,7 @@ from custom_components.ha_govee_led_ble.effect_deployments import (
     DeploymentRecord,
     EffectDeploymentRepository,
     ObservationConfidence,
+    PriorControlState,
 )
 from custom_components.ha_govee_led_ble.effect_domain import (
     LibraryItem,
@@ -40,9 +42,10 @@ from custom_components.ha_govee_led_ble.effect_domain import (
     SourceKind,
     VideoProfile,
 )
-from custom_components.ha_govee_led_ble.effect_identity import EffectDeviceCache
+from custom_components.ha_govee_led_ble.effect_identity import EffectDeviceCache, ObservedDeviceState
 from custom_components.ha_govee_led_ble.effect_runtime import (
     EffectDeploymentEngine,
+    _activation_matches,
 )
 from custom_components.ha_govee_led_ble.generated_protocol_adapter import build_power
 from custom_components.ha_govee_led_ble.layered_scene_decoder import decode_catalogue_layered_scene
@@ -151,6 +154,47 @@ def _music_item(model: str = "H617A") -> LibraryItem:
     )
 
 
+def test_scene_activation_uses_name_only_when_raw_code_is_unavailable() -> None:
+    record = replace(
+        _confirmed_saved_record(_item()),
+        target_mode="scene",
+        target_effect="forest",
+        diy_code=2163,
+    )
+    coordinator = SimpleNamespace(
+        is_on=True,
+        scene_code=212,
+        effect="forest",
+        diy_code=None,
+        unknown_scene_code=None,
+    )
+
+    assert not _activation_matches(coordinator, record)
+    coordinator.scene_code = None
+    assert _activation_matches(coordinator, record)
+
+
+def test_scene_activation_rejects_ambiguous_code_with_a_different_label() -> None:
+    legacy = next(scene for scene in SCENE_ENTRIES["H617A"] if scene.name == "Aurora")
+    record = replace(
+        _confirmed_saved_record(_item(), diy_code=legacy.code),
+        target_mode="scene",
+        target_effect="aurora",
+    )
+    coordinator = SimpleNamespace(
+        is_on=True,
+        model="H617E",
+        scene_code=legacy.code,
+        effect="racing game-a",
+        diy_code=None,
+        unknown_scene_code=None,
+    )
+
+    assert not _activation_matches(coordinator, record)
+    coordinator.effect = "aurora-a"
+    assert _activation_matches(coordinator, record)
+
+
 def _video_item() -> LibraryItem:
     return LibraryItem.new(
         "Movie",
@@ -179,6 +223,7 @@ def _coordinator(*, readable: bool = True):
         rgb_color=(1, 2, 3),
         color_temp_kelvin=None,
         effect=None,
+        scene_code=None,
         unknown_scene_code=None,
         diy_code=None,
         music_mode="off",
@@ -904,6 +949,118 @@ async def test_reconciliation_matches_only_latest_confirmed_selector(
     )
 
     assert changed.active_effect is None
+
+
+async def test_reconciliation_matches_scene_deployments_by_raw_selector_code(
+    hass: HomeAssistant,
+) -> None:
+    repository, cache = await _repositories(hass)
+    item = _item()
+    official_codes = {scene.code for scene in SCENE_ENTRIES["H617E"]}
+    legacy = next(scene for scene in SCENE_ENTRIES["H617A"] if scene.code not in official_codes)
+    confirmed = replace(
+        _confirmed_saved_record(item, diy_code=legacy.code),
+        target_mode="scene",
+        target_effect=legacy.name.casefold(),
+    )
+    await repository.async_put(confirmed, expected_version=None)
+    active_workspaces = ActiveEffectWorkspaceRepository(InMemoryVersionedDocumentStore())
+    await active_workspaces.async_load()
+    active_workspaces.set(
+        replace(
+            _flow_workspace(),
+            model="H617E",
+            selector_label=item.name,
+            content=item.content,
+            origin=item.origin,
+            observable_signature=f"scene:{legacy.name.casefold()}",
+        )
+    )
+    coordinator = _coordinator()
+    coordinator.model = "H617E"
+    coordinator.effect = None
+    coordinator.scene_code = legacy.code
+
+    observed = await EffectDeploymentEngine(repository, cache, active_workspaces).async_reconcile(
+        coordinator,
+        config_entry_id="entry-a",
+        observed_at="2026-08-11T00:01:00Z",
+    )
+
+    assert observed.matched_operation_id == confirmed.operation_id
+    assert observed.active_effect is not None
+    assert observed.active_effect.item_id == item.id
+    workspace = active_workspaces.get("entry-a")
+    assert workspace is not None
+    assert workspace.observable_signature == f"scene-code:{legacy.code}"
+
+
+async def test_reconciliation_does_not_fall_back_to_scene_name_when_codes_differ(
+    hass: HomeAssistant,
+) -> None:
+    repository, cache = await _repositories(hass)
+    item = _item()
+    legacy = next(scene for scene in SCENE_ENTRIES["H617A"] if scene.name == "Forest")
+    exact = next(scene for scene in SCENE_ENTRIES["H617E"] if scene.name == "Forest")
+    await repository.async_put(
+        replace(
+            _confirmed_saved_record(item, diy_code=legacy.code),
+            target_mode="scene",
+            target_effect="forest",
+        ),
+        expected_version=None,
+    )
+    coordinator = _coordinator()
+    coordinator.model = "H617E"
+    coordinator.effect = "forest"
+    coordinator.scene_code = exact.code
+
+    observed = await EffectDeploymentEngine(repository, cache).async_reconcile(
+        coordinator,
+        config_entry_id="entry-a",
+        observed_at="2026-08-11T00:01:00Z",
+    )
+
+    assert observed.matched_operation_id is None
+    assert observed.active_effect is None
+
+
+async def test_prior_state_uses_the_confirmed_scene_identity_for_ambiguous_codes(
+    hass: HomeAssistant,
+) -> None:
+    repository, cache = await _repositories(hass)
+    item = _item()
+    legacy = next(scene for scene in SCENE_ENTRIES["H617A"] if scene.name == "Aurora")
+    confirmed = replace(
+        _confirmed_saved_record(item, diy_code=legacy.code),
+        target_mode="scene",
+        target_effect="aurora",
+    )
+    await repository.async_put(confirmed, expected_version=None)
+    cache.set(
+        ObservedDeviceState(
+            config_entry_id="entry-a",
+            mode="scene",
+            observed_at="2026-08-11T00:01:00Z",
+            matched_operation_id=confirmed.operation_id,
+        )
+    )
+    coordinator = _coordinator()
+    coordinator.capture_effect_control_state = lambda: PriorControlState(
+        mode="scene",
+        is_on=True,
+        brightness_pct=72,
+        rgb_color=(1, 2, 3),
+        effect="racing game-a",
+        scene_code=legacy.code,
+    )
+
+    captured = EffectDeploymentEngine(repository, cache)._capture_prior_state(
+        coordinator,
+        config_entry_id="entry-a",
+    )
+
+    assert captured.effect == "aurora"
 
 
 async def test_matching_flow_workspace_suppresses_saved_sena_selector_history(

--- a/tests/test_effect_scene_codec.py
+++ b/tests/test_effect_scene_codec.py
@@ -45,6 +45,39 @@ def _raw_param(entry: SceneEntry) -> bytes:
     return base64.b64decode(entry.param, validate=True)
 
 
+def test_inert_catalogue_metadata_does_not_enable_scene_compilation() -> None:
+    entry = SCENE_ENTRIES["H6076"][0]
+    item = LibraryItem.new("Unsupported scene", BuiltinScene(_reference("H6076", entry)))
+
+    result = compatibility(item, "H6076")
+
+    assert result.state is CompatibilityState.INCOMPATIBLE
+    assert result.reasons == ("H6076 native scenes are not supported",)
+    with pytest.raises(ValueError, match="native scenes are not supported"):
+        compile_effect(item, "H6076")
+
+
+def test_all_legacy_h617e_saved_scenes_remain_compilable() -> None:
+    for legacy in SCENE_ENTRIES["H617A"]:
+        item = LibraryItem.new(
+            "Legacy H617E scene",
+            BuiltinScene(
+                _reference("H617E", legacy),
+                speed_index=legacy.speed.default_index if legacy.speed is not None else None,
+            ),
+        )
+
+        compiled = compile_effect(item, "H617E")
+
+        assert compiled.packets == tuple(
+            build_native_scene_packets(
+                "H617E",
+                legacy,
+                speed_index=legacy.speed.default_index if legacy.speed is not None else None,
+            )
+        )
+
+
 def _assert_movement(decoded: Any, parsed: Any) -> None:
     assert decoded.enabled is bool(parsed.enabled)
     assert decoded.enter_exit is bool(parsed.enter_exit_effect)
@@ -109,7 +142,6 @@ def test_all_committed_type_2_scenes_decode_losslessly() -> None:
     catalogue_excess = 0
     multi_line_bodies = 0
 
-    assert SCENE_ENTRIES["H617E"] is SCENE_ENTRIES["H617A"]
     for sku in ("H617A", "H6199"):
         entries = SCENE_ENTRIES[sku]
         for entry in entries:

--- a/tests/test_effect_scenes.py
+++ b/tests/test_effect_scenes.py
@@ -1,5 +1,6 @@
 """Native scene editor contracts."""
 
+import asyncio
 import base64
 import binascii
 from dataclasses import replace
@@ -13,10 +14,13 @@ from homeassistant.core import HomeAssistant
 from custom_components.ha_govee_led_ble.effect_scene_defaults import NativeSceneDefault, NativeSceneDefaultRepository
 from custom_components.ha_govee_led_ble.effect_scenes import (
     async_apply_scene,
+    async_delete_scene_defaults,
     async_reset_scene_default,
     async_set_scene_default,
+    async_store_scene_default,
     resolve_scene,
     scene_catalogue_payload,
+    scene_default_for,
     scene_detail_payload,
 )
 from custom_components.ha_govee_led_ble.native_scenes import resolve_native_scene_body
@@ -40,6 +44,146 @@ def test_catalogue_and_identity_errors() -> None:
         resolve_scene("H617A", -1, -1)
 
     assert scene_catalogue_payload("H6199")["enabled"] is True
+    assert scene_catalogue_payload("H6076")["enabled"] is False
+
+
+def test_h617e_legacy_scene_identity_preserves_its_original_metadata() -> None:
+    legacy = MODEL_SCENES["H617A"]["sunrise"]
+
+    resolved = resolve_scene("H617E", legacy.scene_id, legacy.effect_id)
+    detail = scene_detail_payload("H617E", legacy.scene_id, legacy.effect_id)
+
+    assert resolved.entry == legacy
+    content = cast(dict[str, Any], detail["content"])
+    assert content["template"] == {
+        "sku": "H617E",
+        "scene_id": legacy.scene_id,
+        "effect_id": legacy.effect_id,
+        "catalogue_schema_version": 1,
+    }
+
+
+async def test_h617e_exact_scene_finds_a_legacy_saved_default() -> None:
+    legacy = MODEL_SCENES["H617A"]["sunrise"]
+    exact = MODEL_SCENES["H617E"]["sunrise"]
+    resolved = resolve_scene("H617E", exact.scene_id, exact.effect_id)
+    repository = NativeSceneDefaultRepository(InMemoryVersionedDocumentStore())
+    await repository.async_load()
+    await repository.async_set(
+        NativeSceneDefault(
+            config_entry_id="entry-a",
+            scene_id=legacy.scene_id,
+            effect_id=legacy.effect_id,
+            updated_at=TIMESTAMP,
+            canonical_body=b"\x01",
+        )
+    )
+
+    migrated = scene_default_for(
+        repository,
+        "entry-a",
+        "H617E",
+        resolved.key,
+        resolved.entry,
+    )
+
+    assert migrated is not None
+    assert (migrated.scene_id, migrated.effect_id) == (exact.scene_id, exact.effect_id)
+    assert migrated.canonical_body == b"\x01"
+
+
+async def test_h617e_legacy_scene_finds_and_deletes_an_exact_saved_default() -> None:
+    legacy = MODEL_SCENES["H617A"]["aurora"]
+    exact = MODEL_SCENES["H617E"]["aurora-a"]
+    resolved = resolve_scene("H617E", legacy.scene_id, legacy.effect_id)
+    repository = NativeSceneDefaultRepository(InMemoryVersionedDocumentStore())
+    await repository.async_load()
+    await repository.async_set(
+        NativeSceneDefault(
+            config_entry_id="entry-a",
+            scene_id=exact.scene_id,
+            effect_id=exact.effect_id,
+            updated_at=TIMESTAMP,
+            canonical_body=b"\x01",
+        )
+    )
+
+    migrated = scene_default_for(repository, "entry-a", "H617E", resolved.key, resolved.entry)
+
+    assert migrated is not None
+    assert migrated.canonical_body == b"\x01"
+    await async_delete_scene_defaults(repository, "entry-a", "H617E", resolved)
+    assert repository.get("entry-a", exact.scene_id, exact.effect_id) is None
+
+
+async def test_h617e_alias_default_replacement_is_atomic() -> None:
+    legacy = MODEL_SCENES["H617A"]["aurora"]
+    exact = MODEL_SCENES["H617E"]["aurora-a"]
+    legacy_resolved = resolve_scene("H617E", legacy.scene_id, legacy.effect_id)
+    exact_resolved = resolve_scene("H617E", exact.scene_id, exact.effect_id)
+    repository = NativeSceneDefaultRepository(InMemoryVersionedDocumentStore())
+    await repository.async_load()
+
+    await asyncio.gather(
+        async_store_scene_default(
+            repository,
+            "entry-a",
+            "H617E",
+            legacy_resolved,
+            updated_at=TIMESTAMP,
+            canonical_body=b"\x01",
+            speed_index=None,
+        ),
+        async_store_scene_default(
+            repository,
+            "entry-a",
+            "H617E",
+            exact_resolved,
+            updated_at=TIMESTAMP,
+            canonical_body=b"\x02",
+            speed_index=None,
+        ),
+    )
+
+    values = (
+        repository.get("entry-a", legacy.scene_id, legacy.effect_id),
+        repository.get("entry-a", exact.scene_id, exact.effect_id),
+    )
+    assert sum(value is not None for value in values) == 1
+
+
+async def test_h617e_legacy_default_is_normalised_and_deleted_with_the_exact_scene() -> None:
+    key, legacy = next(
+        (key, entry)
+        for key, entry in MODEL_SCENES["H617A"].items()
+        if entry.speed is not None and key in MODEL_SCENES["H617E"] and MODEL_SCENES["H617E"][key].speed is None
+    )
+    exact = MODEL_SCENES["H617E"][key]
+    assert legacy.speed is not None
+    resolved = resolve_scene("H617E", exact.scene_id, exact.effect_id)
+    repository = NativeSceneDefaultRepository(InMemoryVersionedDocumentStore())
+    await repository.async_load()
+    await repository.async_set(
+        NativeSceneDefault(
+            config_entry_id="entry-a",
+            scene_id=legacy.scene_id,
+            effect_id=legacy.effect_id,
+            updated_at=TIMESTAMP,
+            canonical_body=b"\x01",
+            speed_index=legacy.speed.default_index,
+        )
+    )
+
+    migrated = scene_default_for(repository, "entry-a", "H617E", resolved.key, resolved.entry)
+
+    assert migrated is not None
+    assert (migrated.scene_id, migrated.effect_id, migrated.speed_index) == (
+        exact.scene_id,
+        exact.effect_id,
+        None,
+    )
+    await async_delete_scene_defaults(repository, "entry-a", "H617E", resolved)
+    assert repository.get("entry-a", legacy.scene_id, legacy.effect_id) is None
 
 
 def test_layered_scene_detail_decodes_strict_base64_template(monkeypatch) -> None:
@@ -185,6 +329,7 @@ async def test_scene_without_speed_uses_coordinator_primitive(
     assert speed_index is None
     coordinator.async_apply_native_scene.assert_awaited_once_with(
         resolved.key,
+        scene_entry=resolved.entry,
         speed_index=None,
         canonical_body=base64.b64decode(scene.param, validate=True) if scene.param else None,
     )
@@ -227,6 +372,7 @@ async def test_scene_application_uses_the_stored_device_default(
     assert applied_speed == 0
     coordinator.async_apply_native_scene.assert_awaited_once_with(
         resolved.key,
+        scene_entry=resolved.entry,
         speed_index=0,
         canonical_body=body,
     )
@@ -238,7 +384,7 @@ async def test_reset_deletes_default_without_applying_to_the_device() -> None:
         model="H617A",
         async_apply_native_scene=AsyncMock(),
     )
-    repository = SimpleNamespace(async_delete=AsyncMock())
+    repository = SimpleNamespace(async_replace_identities=AsyncMock())
     entry = SimpleNamespace(entry_id="entry-a", runtime_data=coordinator)
 
     await async_reset_scene_default(
@@ -248,7 +394,11 @@ async def test_reset_deletes_default_without_applying_to_the_device() -> None:
         scene_defaults=repository,
     )
 
-    repository.async_delete.assert_awaited_once_with("entry-a", scene.scene_id, scene.effect_id)
+    repository.async_replace_identities.assert_awaited_once_with(
+        "entry-a",
+        ((scene.scene_id, scene.effect_id),),
+        None,
+    )
     coordinator.async_apply_native_scene.assert_not_awaited()
 
 

--- a/tests/test_layered_scene.py
+++ b/tests/test_layered_scene.py
@@ -144,6 +144,7 @@ def _assert_layer_matches(decoded: EffectLayer, parsed: Any) -> None:
 def test_advanced_layers_compile_with_byte_exact_model_framing() -> None:
     carriers = {
         "H617A": (1013, 11836),
+        "H617E": (29884, 41599),
         "H6199": (29884, 41599),
     }
     effect = LayeredEffect((_layer(),))
@@ -451,7 +452,6 @@ def test_all_committed_layered_scenes_round_trip_canonical_values() -> None:
     scene_counts: Counter[str] = Counter()
     record_count = 0
 
-    assert SCENE_ENTRIES["H617E"] is SCENE_ENTRIES["H617A"]
     for sku in ("H617A", "H6199"):
         entries = SCENE_ENTRIES[sku]
         for entry in entries:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -233,9 +233,10 @@ def test_effect_lists(h6199_light, light, mock_coordinator, mock_h6199_coordinat
 
 
 def test_selector_projection_preserves_unique_aliases_and_rejects_built_in_ambiguity():
+    h617x_categories = frozenset({"scenes", "effects", "multi_layered", "reactive", "advanced"})
     h617a = effect_selector_entries(
         "H617A",
-        frozenset({"scenes", "effects", "multi_layered", "reactive", "advanced"}),
+        h617x_categories,
         (),
         prefix_effect_names=False,
     )
@@ -245,6 +246,37 @@ def test_selector_projection_preserves_unique_aliases_and_rejects_built_in_ambig
     assert resolve_effect_selector(h617a, "Energetic [Reactive]").source == "music"
     with pytest.raises(EffectValidationError, match="ambiguous"):
         resolve_effect_selector(h617a, "Energetic")
+
+    h617e = effect_selector_entries(
+        "H617E",
+        frozenset({"scenes", "effects", "multi_layered", "reactive", "advanced"}),
+        (),
+        prefix_effect_names=False,
+    )
+    assert resolve_effect_selector(h617e, "aurora").value == "aurora-a"
+    assert resolve_effect_selector(h617e, "Scene: Aurora").value == "aurora-a"
+    assert resolve_effect_selector(h617e, "Energetic [Scene]").value == "energetic-a"
+    assert resolve_effect_selector(h617e, "flying").value == "flying"
+    with pytest.raises(EffectValidationError, match="ambiguous"):
+        resolve_effect_selector(h617e, "Energetic")
+    for prefix_effect_names in (False, True):
+        legacy = effect_selector_entries(
+            "H617A",
+            h617x_categories,
+            (),
+            prefix_effect_names=prefix_effect_names,
+        )
+        current = effect_selector_entries(
+            "H617E",
+            h617x_categories,
+            (),
+            prefix_effect_names=prefix_effect_names,
+        )
+        assert all(
+            resolve_effect_selector(current, entry.display_label).source == "scene"
+            for entry in legacy
+            if entry.source == "scene"
+        )
 
     h6199 = effect_selector_entries(
         "H6199",

--- a/tests/test_palette_scene_decoder.py
+++ b/tests/test_palette_scene_decoder.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 import pytest
 from kaitaistruct import KaitaiStructError
 
+from custom_components.ha_govee_led_ble.const import get_profile
 from custom_components.ha_govee_led_ble.effect_compiler import (
     ActivationMode,
     CompatibilityState,
@@ -91,9 +92,9 @@ def test_all_committed_h617a_type_1_scenes_decode_losslessly() -> None:
 def test_encode_round_trips_every_committed_type_1_scene() -> None:
     fixtures = 0
 
-    assert SCENE_ENTRIES["H617E"] is SCENE_ENTRIES["H617A"]
-    for sku in ("H617A", "H6199"):
-        entries = SCENE_ENTRIES[sku]
+    for sku, entries in SCENE_ENTRIES.items():
+        if not get_profile(sku).supports_scenes:
+            continue
         for entry in entries:
             if entry.scene_type != 1:
                 continue
@@ -103,11 +104,13 @@ def test_encode_round_trips_every_committed_type_1_scene() -> None:
             assert encode_palette_scene(decoded) == raw_param
             fixtures += 1
 
-    assert fixtures == 4
+    assert fixtures == 6
 
 
 def test_committed_palette_scenes_compile_to_byte_exact_model_frames() -> None:
     for model, entries in SCENE_ENTRIES.items():
+        if not get_profile(model).supports_scenes:
+            continue
         entry = next(scene for scene in entries if scene.scene_type == 1)
         decoded = decode_catalogue_palette_scene(model, entry)
         assert decoded is not None

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -19,6 +19,7 @@ from custom_components.ha_govee_led_ble.native_scenes import (
     build_native_scene_packets,
 )
 from custom_components.ha_govee_led_ble.scenes import (
+    MODEL_SCENE_ALIASES,
     MODEL_SCENES,
     SCENE_ENTRIES,
     SCENES,
@@ -65,12 +66,25 @@ def test_scene_type_prefix():
 
 def test_per_model_snapshots_preserve_vendor_identity():
     assert len(SCENE_ENTRIES["H617A"]) == 83
+    assert len(SCENE_ENTRIES["H617E"]) == 240
+    assert len(SCENE_ENTRIES["H6076"]) == 110
     assert len(SCENE_ENTRIES["H6199"]) == 240
+    assert SCENE_ENTRIES["H617E"] is not SCENE_ENTRIES["H617A"]
+    assert len(MODEL_SCENES["H617E"]) == 247
+    assert all(key in MODEL_SCENES["H617E"] or key in MODEL_SCENE_ALIASES["H617E"] for key in MODEL_SCENES["H617A"])
     assert len({(scene.scene_id, scene.effect_id) for scene in SCENE_ENTRIES["H6199"]}) == 240
     assert MODEL_SCENES["H6199"]["dracarys"].category == "House of the Dragon"
     assert MODEL_SCENES["H6199"]["green reign"].code == 16183
     assert MODEL_SCENES["H6199"]["fire & blood"].code == 16184
     assert {"flash [emotion]", "flash [zootopia 2]"} <= MODEL_SCENES["H6199"].keys()
+
+
+def test_h617e_uses_its_exact_catalogue_with_the_shared_wire_adapter():
+    selector = next(scene for scene in SCENE_ENTRIES["H617E"] if scene.scene_type == 0)
+    uploaded = next(scene for scene in SCENE_ENTRIES["H617E"] if scene.scene_type == 2)
+
+    assert build_native_scene_packets("H617E", selector) == [build_h617a_scene(selector.code)]
+    assert build_native_scene_packets("H617E", uploaded)[-1] == build_h617a_scene(uploaded.code)
 
 
 def test_aurora_b_matches_current_ios_capture():
@@ -209,8 +223,7 @@ def test_generated_scene_body_parser_round_trips_type_2_catalogues():
     scene_counts: Counter[str] = Counter()
     record_count = 0
 
-    assert SCENE_ENTRIES["H617E"] is SCENE_ENTRIES["H617A"]
-    for sku in ("H617A", "H6199"):
+    for sku in ("H6076", "H617A", "H617E", "H6199"):
         entries = SCENE_ENTRIES[sku]
         for entry in entries:
             if entry.scene_type != int(SceneBody.SceneType.scene_v2):
@@ -231,8 +244,8 @@ def test_generated_scene_body_parser_round_trips_type_2_catalogues():
             scene_counts[sku] += 1
             record_count += len(parsed.records)
 
-    assert scene_counts == {"H617A": 72, "H6199": 226}
-    assert record_count == 863
+    assert scene_counts == {"H6076": 101, "H617A": 72, "H617E": 226, "H6199": 226}
+    assert record_count == 1799
 
 
 @pytest.mark.parametrize("raw_param", [bytearray(b"\x00"), memoryview(b"\x00"), "\x00"])

--- a/tools/generate_frontend_contract_fixtures.py
+++ b/tools/generate_frontend_contract_fixtures.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from custom_components.ha_govee_led_ble.const import MODEL_PROFILES
 from custom_components.ha_govee_led_ble.effect_catalogue import (
+    MODEL_EFFECT_CATALOGUES,
     WORKSHOP_PROTOCOL_FIXTURES,
     custom_effect_catalogue_payload,
 )
@@ -54,7 +55,7 @@ from custom_components.ha_govee_led_ble.scenes import SCENE_ENTRIES
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT_PATH = REPO_ROOT / "frontend" / "tests" / "fixtures" / "backend-contracts.json"
-MODELS = ("H617A", "H617E", "H6199")
+MODELS = tuple(MODEL_EFFECT_CATALOGUES)
 TIMESTAMP = "2026-08-17T00:00:00Z"
 ITEM_ID = UUID("00000000-0000-4000-8000-000000000001")
 DEPLOYMENT_ID = UUID("00000000-0000-4000-8000-000000000003")


### PR DESCRIPTION
## Summary

- make the existing `ModelProfile` registry the shared source for product capabilities, read domains, catalogue identity, limits, defaults, and support quality
- keep generated Kaitai adapters as the wire-operation boundary while removing duplicated model and frontend SKU gates
- give H617E an exact product profile and official 240-scene catalogue while preserving prior selector names, saved scenes, defaults, verification, recovery, and active workspaces
- make Effect Studio and frontend validation consume backend capability and catalogue payloads rather than compile-time model lists
- make `CONTRIBUTING.md` canonical for architecture, model planning, support lifecycle, non-goals, and validation
- simplify the README to current-state support information and a compact Effect Studio overview

## Validation

- `make check`