### PR TITLE
fix: separate device support boundaries for protocol reuse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,15 @@ Do not post the Bluetooth address, serial number, account details, or other uniq
 
 Every exact SKU has its own profile, support quality, catalogue identity, and product capability data.  Compatible models may share a Kaitai wire adapter, but do not share whole profiles or exact-SKU metadata.
 
+### Reusing device protocol support
+
+- Declare `effect_grammar` independently of basic `wire_model` compatibility. It selects A3 and Workshop codecs, including their canonical semantics; it does not authorize effect application, catalogue reuse, activation, or readback policy. Workshop application also requires the exact-model capability contract and an implemented activation route.
+- Declare each model's `music_modes` explicitly. The shared slug-to-wire-ID registry records encoding knowledge, not product support.
+- Pass the effective device profile to semantic segment builders. Construct and validate the entire request before cancelling previews, acquiring user control, changing optimistic state, or writing to BLE. Whole-device masks remain separate from individually selectable segments.
+- Reuse `govee_segment_page` in status KSY with the evidenced segment count, page size, and unused-byte rule. Its fixed page body has four wire slots; only the declared meaningful records contribute to observed state. Keep profile counts consistent with the selected schema, and preserve uncertain unused bytes rather than treating zero-valued records as absent.
+
+Extension tests should demonstrate reuse through declarations without unrelated exact-model codec allowlist edits. Synthetic profiles and speculative fixtures establish these software boundaries, not physical device compatibility.
+
 ## Planning support for a new model
 
 Use the same short structure for human and agent plans:

--- a/custom_components/ha_govee_led_ble/const.py
+++ b/custom_components/ha_govee_led_ble/const.py
@@ -77,6 +77,8 @@ class ModelProfile:
     name: str
     support_quality: SupportQuality = SupportQuality.EXPERIMENTAL
     wire_model: str | None = None
+    # Effect semantics require evidence independent of basic command compatibility.
+    effect_grammar: str | None = None
     read_domains: frozenset[ReadDomain] = frozenset()
     setup_required_read_domains: frozenset[ReadDomain] = frozenset()
     supports_rgb: bool = False
@@ -165,6 +167,7 @@ _H617A_PROFILE = ModelProfile(
     "H617A LED Strip",
     support_quality=SupportQuality.SUPPORTED,
     wire_model="H617A",
+    effect_grammar="H617A",
     read_domains=frozenset(
         {
             ReadDomain.POWER,
@@ -186,7 +189,19 @@ _H617A_PROFILE = ModelProfile(
     supports_color_temperature=True,
     supports_custom_effects=True,
     supports_scenes=True,
-    music_modes=tuple(MUSIC_MODE_SLUGS),
+    music_modes=(
+        "energetic",
+        "rhythm",
+        "spectrum",
+        "rolling",
+        "separation",
+        "hopping",
+        "piano_keys",
+        "fountain",
+        "day_and_night",
+        "bloom",
+        "shiny",
+    ),
     supports_music_color=True,
     supports_advanced_effects=True,
     supports_multi_layered_effects=True,
@@ -213,6 +228,20 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
         _H617A_PROFILE,
         name="H617E LED Strip",
         support_quality=SupportQuality.COMPATIBLE,
+        effect_grammar="H617A",
+        music_modes=(
+            "energetic",
+            "rhythm",
+            "spectrum",
+            "rolling",
+            "separation",
+            "hopping",
+            "piano_keys",
+            "fountain",
+            "day_and_night",
+            "bloom",
+            "shiny",
+        ),
         scene_catalogue_sku="H617E",
         legacy_scene_catalogue_sku="H617A",
         advanced_scene_carrier=(29884, 41599),
@@ -241,6 +270,7 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
         "H6199 DreamView T1",
         support_quality=SupportQuality.SUPPORTED,
         wire_model="H6199",
+        effect_grammar="H6199",
         read_domains=frozenset(
             {
                 ReadDomain.POWER,
@@ -308,6 +338,7 @@ def model_from_ble_name(name: str) -> str | None:
 
 
 def protocol_model(model: str) -> str | None:
+    """Resolve legacy runtime policy identity, not effect-grammar compatibility."""
     resolved = resolve_model(model)
     return "H617A" if resolved in {"H617A", "H617E"} else resolved
 

--- a/custom_components/ha_govee_led_ble/coordinator.py
+++ b/custom_components/ha_govee_led_ble/coordinator.py
@@ -677,12 +677,22 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         self._segment_query_brightness = None
 
     def _apply_segment_group(self, generated: Any) -> tuple[str, ...]:
-        group = int(generated.body.group)
-        records = generated.body.segments
+        group = getattr(generated.body, "group", None)
+        records = getattr(generated.body, "segments", None)
+        count = getattr(generated.body, "num_segments", None)
         group_size = self.profile.segment_group_size
+        if type(group) is not int or not 1 <= group <= self._segment_group_count:
+            raise ValueError("invalid segment group for model")
         offset = (group - 1) * group_size
-        if offset < 0 or offset + len(records) > self.profile.segment_count:
-            raise ValueError("segment group exceeds model segment count")
+        expected_count = min(group_size, self.profile.segment_count - offset)
+        if type(count) is not int or count != expected_count or not isinstance(records, list) or len(records) != count:
+            raise ValueError("segment record count does not match model page")
+        # Convert the entire page before touching an in-progress observation.
+        try:
+            page_colours = [(int(r.colour.red), int(r.colour.green), int(r.colour.blue)) for r in records]
+            page_brightness = [int(r.brightness) for r in records]
+        except (AttributeError, TypeError, ValueError) as err:
+            raise ValueError("malformed segment record") from err
         colours = self._segment_query_colors
         brightness = self._segment_query_brightness
         if colours is None or brightness is None:
@@ -690,14 +700,8 @@ class GoveeBLECoordinator(_ActiveModeMixin):
             brightness = list(self.segment_brightness)
             self._segment_query_colors = colours
             self._segment_query_brightness = brightness
-        for index, record in enumerate(records, start=offset):
-            level = int(record.brightness_percent) if self.model == "H6199" else int(record.brightness)
-            colours[index] = (
-                int(record.colour.red),
-                int(record.colour.green),
-                int(record.colour.blue),
-            )
-            brightness[index] = level
+        colours[offset : offset + count] = page_colours
+        brightness[offset : offset + count] = page_brightness
         self._segment_groups_observed.add(group)
         if len(self._segment_groups_observed) != self._segment_group_count:
             return ()
@@ -705,6 +709,7 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         self.segment_brightness = brightness
         self._segment_query_colors = None
         self._segment_query_brightness = None
+        self._segment_groups_observed.clear()
         self.segment_state_source = "observed"
         self.segment_state_observed_at = datetime.now().astimezone().isoformat()
         observed = ["segment_colors", "segment_brightness"]
@@ -1587,11 +1592,8 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         publish segment state after writes, so the complete segment query verifies the
         optimistic state without resending or rolling back a completed write.
         """
-        if not self.profile.supports_segments:
-            raise ValueError(f"{self.model} does not support per-segment control")
         resolved: list[SegmentColorGroup] = [(list(segments), rgb) for segments, rgb in groups]
-        if not resolved or any(not segments for segments, _rgb in resolved):
-            raise ValueError("at least one non-empty segment group is required")
+        packets = build_segment_paint(resolved, self.model, profile=self.profile)
         previous = list(self.segment_colors)
         previous_source = self.segment_state_source
         previous_observed_at = self.segment_state_observed_at
@@ -1602,11 +1604,9 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         try:
             for segments, rgb in resolved:
                 for segment in segments:
-                    if not 1 <= segment <= self.profile.segment_count:
-                        raise ValueError(f"segment {segment} out of range 1..{self.profile.segment_count}")
                     updated[segment - 1] = rgb
             self.mark_segment_state_optimistic(colours=updated)
-            for packet in build_segment_paint(resolved, self.model):
+            for packet in packets:
                 await self.send_command(packet)
         except Exception:
             self.segment_colors = previous
@@ -1621,17 +1621,12 @@ class GoveeBLECoordinator(_ActiveModeMixin):
         self.async_set_updated_data(self.data or {})
 
     async def async_set_segment_brightness(self, segments: list[int], brightness: int) -> None:
-        if not self.profile.supports_segments:
-            raise ValueError(f"{self.model} does not support per-segment control")
-        if not segments:
-            raise ValueError("at least one segment is required")
+        segments = list(segments)
         value = max(0, min(100, brightness))
+        packet = build_segment_brightness(segments, value, self.model, profile=self.profile)
         updated = list(self.segment_brightness)
         for segment in segments:
-            if not 1 <= segment <= self.profile.segment_count:
-                raise ValueError(f"segment {segment} out of range 1..{self.profile.segment_count}")
             updated[segment - 1] = value
-        packet = build_segment_brightness(segments, value, self.model)
         await self.send_command(packet)
         self.mark_segment_state_optimistic(brightness=updated)
         self._enter_static_mode()

--- a/custom_components/ha_govee_led_ble/effect_compiler.py
+++ b/custom_components/ha_govee_led_ble/effect_compiler.py
@@ -33,7 +33,12 @@ from .effect_commands import (
     build_h6199_palette_diy,
     build_h6199_palette_diy_activation,
 )
-from .effect_contracts import EFFECT_COMPILER_VERSION
+from .effect_contracts import (
+    EFFECT_COMPILER_VERSION,
+    CapabilityState,
+    CapabilityWorkflow,
+    studio_apply_capability_state,
+)
 from .effect_domain import (
     BuiltinScene,
     LayeredEffect,
@@ -180,6 +185,10 @@ def compatibility(item: LibraryItem, model: str) -> CompatibilityResult:
                 CompatibilityState.INCOMPATIBLE,
                 (f"Workshop effect targets {content.model}, not {model}",),
             )
+        try:
+            workshop_apply_code(model)
+        except ValueError as error:
+            return CompatibilityResult(CompatibilityState.INCOMPATIBLE, (str(error),))
         return CompatibilityResult(CompatibilityState.COMPATIBLE)
     if isinstance(content, BuiltinScene):
         if not get_profile(model).supports_scenes:
@@ -274,17 +283,31 @@ def compile_effect(item: LibraryItem, model: str, *, diy_code: int | None = None
     if isinstance(item.content, BuiltinScene | PaletteScene | LayeredScene | LayeredEffect):
         return compile_scene_effect(item, model)
     if isinstance(item.content, WorkshopEffect):
-        expected_code = H6199_WORKSHOP_APPLY_CODE if model == "H6199" else H617A_WORKSHOP_APPLY_CODE
+        expected_code = workshop_apply_code(model)
         if diy_code is not None and diy_code != expected_code:
             raise ValueError("Workshop has no evidenced activation packet for the requested slot")
         return _compile_workshop_effect(item, model)
     raise ValueError("unsupported effect content")
 
 
+def workshop_apply_code(model: str) -> int:
+    """Require Workshop authorization and an evidenced grammar/activation pair."""
+    if studio_apply_capability_state(model, CapabilityWorkflow.WORKSHOP) is not CapabilityState.SUPPORTED:
+        raise ValueError(f"{model} Workshop application is not supported")
+    profile = get_profile(model)
+    if profile.effect_grammar == "H617A" and profile.wire_model == "H617A":
+        return H617A_WORKSHOP_APPLY_CODE
+    if profile.effect_grammar == "H6199" and profile.wire_model == "H6199":
+        return H6199_WORKSHOP_APPLY_CODE
+    raise ValueError(f"{model} has no supported Workshop grammar and activation route")
+
+
 def _compile_workshop_effect(
     item: LibraryItem,
     model: str,
 ) -> CompiledEffect:
+    diy_code = workshop_apply_code(model)
+    grammar = get_profile(model).effect_grammar
     content = item.content
     if isinstance(content, WorkshopEffect):
         payload = encode_workshop_effect(
@@ -292,17 +315,15 @@ def _compile_workshop_effect(
             content.effect,
             trailing_padding=content.trailing_padding,
         )
-        body_kind = int(H6199EffectUpload.BodyKind.scene) if model == "H6199" else int(SceneBody.SceneType.scene_v2)
+        body_kind = int(H6199EffectUpload.BodyKind.scene) if grammar == "H6199" else int(SceneBody.SceneType.scene_v2)
         upload = tuple(fragment_a3(body_kind, payload))
         content_kind = "workshop"
     else:
         raise ValueError("content is not an upload-only effect")
 
-    if model == "H6199":
-        diy_code = H6199_WORKSHOP_APPLY_CODE
+    if grammar == "H6199":
         activation = build_h6199_scene(diy_code, H6199_WORKSHOP_APPLY_MUSIC_CODE)
     else:
-        diy_code = H617A_WORKSHOP_APPLY_CODE
         activation = build_h617a_scene(diy_code, scene_type=H617A_WORKSHOP_SCENE_TYPE)
     packets = (*upload, activation)
     return CompiledEffect(

--- a/custom_components/ha_govee_led_ble/effect_protocol_decoder.py
+++ b/custom_components/ha_govee_led_ble/effect_protocol_decoder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .const import protocol_model
+from .const import get_profile
 from .effect_catalogue import (
     H617A_PAINTED_EFFECTS,
     H617A_TYPE04_FAMILIES,
@@ -52,8 +52,8 @@ def decode_a3_effect_frames(
 
 def decode_a3_effect(tree: Any, model: str) -> EffectContent:
     """Decode a parsed generated A3 tree without assigning unevidenced semantics."""
-    model = protocol_model(model) or model
-    if model == "H617A":
+    grammar = get_profile(model).effect_grammar
+    if grammar == "H617A":
         if isinstance(tree, DiyType03):
             return _decode_h617a_painted(tree)
         if isinstance(tree, DiyType04):
@@ -66,11 +66,11 @@ def decode_a3_effect(tree: Any, model: str) -> EffectContent:
             )
         raise TypeError("tree is not a generated H617A A3 effect root")
 
-    if model == "H6199":
+    if grammar == "H6199":
         if not isinstance(tree, H6199EffectUpload):
             raise TypeError("tree is not a generated H6199 A3 effect root")
         if tree.kind == H6199EffectUpload.BodyKind.diy:
-            return _decode_h6199_palette_diy(tree)
+            return _decode_h6199_palette_diy(tree, model)
         if tree.kind == H6199EffectUpload.BodyKind.scene:
             return _decode_layered_tree(tree, model)
         if tree.kind == H6199EffectUpload.BodyKind.builtin_parameters:
@@ -140,7 +140,7 @@ def _decode_h617a_type04(tree: Any) -> SingleEffect | MultiEffect:
     return MultiEffect(effects=effects, speed=body.speed, palette=palette)
 
 
-def _decode_h6199_palette_diy(tree: Any) -> PaletteDiyEffect:
+def _decode_h6199_palette_diy(tree: Any, model: str) -> PaletteDiyEffect:
     if tree.chunk_count != tree.diy_chunk_count:
         raise UnsupportedA3EffectError(
             f"H6199 palette DIY requires {tree.diy_chunk_count} chunks, received {tree.chunk_count}"
@@ -156,7 +156,7 @@ def _decode_h6199_palette_diy(tree: Any) -> PaletteDiyEffect:
         raise UnsupportedA3EffectError("H6199 palette DIY length does not match its generated tree")
     _require_zero_padding(content.padding, "H6199 palette DIY")
     return PaletteDiyEffect(
-        model="H6199",
+        model=model,
         family=family,
         variant=content.variant,
         speed=content.speed,

--- a/custom_components/ha_govee_led_ble/effect_runtime.py
+++ b/custom_components/ha_govee_led_ble/effect_runtime.py
@@ -18,9 +18,7 @@ from .effect_active_workspace import (
 )
 from .effect_catalogue import (
     H617A_TYPE04_APPLY_CODE,
-    H617A_WORKSHOP_APPLY_CODE,
     H6199_PALETTE_DIY_APPLY_CODE,
-    H6199_WORKSHOP_APPLY_CODE,
 )
 from .effect_compiler import (
     ActivationMode,
@@ -29,6 +27,7 @@ from .effect_compiler import (
     CompiledMusicProfile,
     CompiledVideoProfile,
     compile_application,
+    workshop_apply_code,
 )
 from .effect_deployments import (
     DeploymentPhase,
@@ -1142,11 +1141,10 @@ def resolve_diy_code(
             raise ValueError("profiles do not use a DIY code")
         return None
     if isinstance(content, WorkshopEffect):
-        if requested is not None:
-            expected = H6199_WORKSHOP_APPLY_CODE if content.model == "H6199" else H617A_WORKSHOP_APPLY_CODE
-            if requested != expected:
-                raise ValueError("Workshop activation slot does not match the evidenced model slot")
-        return H6199_WORKSHOP_APPLY_CODE if content.model == "H6199" else H617A_WORKSHOP_APPLY_CODE
+        expected = workshop_apply_code(content.model)
+        if requested is not None and requested != expected:
+            raise ValueError("Workshop activation slot does not match the evidenced model slot")
+        return expected
     if isinstance(content, PaintedEffect):
         return 800 if requested is None else requested
     if isinstance(content, SingleEffect | MultiEffect):

--- a/custom_components/ha_govee_led_ble/generated_protocol_adapter.py
+++ b/custom_components/ha_govee_led_ble/generated_protocol_adapter.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 
 from kaitaistruct import ConsistencyError, KaitaiStream, KaitaiStructError, ReadWriteKaitaiStruct
 
-from .const import protocol_model, wire_model
+from .const import get_profile, wire_model
 from .transport import A3_CHUNK_SIZE, xor_checksum
 
 CommandWrite = cast(
@@ -228,8 +228,8 @@ def parse_a3_effect_envelope(envelope: bytes, model: str) -> Any:
     if envelope[1] != len(envelope) // A3_CHUNK_SIZE:
         raise ValueError("A3 effect envelope does not match its chunk count")
 
-    model = protocol_model(model) or model
-    if model == "H617A":
+    grammar = get_profile(model).effect_grammar
+    if grammar == "H617A":
         root_type = {
             0x01: SceneType1Body,
             0x02: SceneBody,
@@ -238,7 +238,7 @@ def parse_a3_effect_envelope(envelope: bytes, model: str) -> Any:
         }.get(envelope[2])
         if root_type is None:
             raise ValueError(f"H617A A3 body type 0x{envelope[2]:02x} is not supported")
-    elif model == "H6199":
+    elif grammar == "H6199":
         root_type = H6199EffectUpload
     else:
         raise ValueError(f"{model} has no generated A3 effect grammar")

--- a/custom_components/ha_govee_led_ble/layered_scene_decoder.py
+++ b/custom_components/ha_govee_led_ble/layered_scene_decoder.py
@@ -6,7 +6,7 @@ import base64
 from collections.abc import Callable
 from typing import Any
 
-from .const import protocol_model
+from .const import get_profile
 from .generated_protocol_adapter import (
     GoveeShared,
     H6199EffectUpload,
@@ -104,11 +104,11 @@ def decode_workshop_effect(
     raw_param: bytes,
 ) -> tuple[LayeredEffect, int]:
     """Decode a Workshop parameter through its model-specific generated structure."""
-    model = protocol_model(model) or model
-    if model == "H617A":
+    grammar = get_profile(model).effect_grammar
+    if grammar == "H617A":
         parsed, trailing_padding = parse_workshop_body(raw_param)
         records = parsed.layers
-    elif model == "H6199":
+    elif grammar == "H6199":
         parsed, trailing_padding = parse_h6199_workshop_content(raw_param)
         records = parsed.blocks
     else:
@@ -123,9 +123,9 @@ def encode_workshop_effect(
     trailing_padding: int = 0,
 ) -> bytes:
     """Serialize Workshop layers through the model-specific generated structure."""
-    model = protocol_model(model) or model
+    grammar = get_profile(model).effect_grammar
     serializer: Callable[[Any], bytes]
-    if model == "H617A":
+    if grammar == "H617A":
         root = WorkshopBody()
         root.a3_type = b"\x02"
         root.num_layers = len(effect.layers)
@@ -133,7 +133,7 @@ def encode_workshop_effect(
         root.padding = [0] * trailing_padding
         serializer = serialize_workshop_body_param
         value = root
-    elif model == "H6199":
+    elif grammar == "H6199":
         root = H6199EffectUpload()
         content = new_child(H6199EffectUpload.SceneContent, root)
         content.num_blocks = len(effect.layers)

--- a/custom_components/ha_govee_led_ble/light_commands.py
+++ b/custom_components/ha_govee_led_ble/light_commands.py
@@ -4,7 +4,7 @@ import math
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from .const import get_profile
+from .const import ModelProfile, get_profile
 from .generated_protocol_adapter import (
     build_colour_temperature,
     build_segment_colour,
@@ -25,16 +25,20 @@ def _clamp(value: int, minimum: int, maximum: int) -> int:
     return max(minimum, min(maximum, value))
 
 
-def segments_to_mask(segments: Iterable[int]) -> int:
-    """Map one-based segment numbers to the device's 15-bit segment mask."""
-    selected = set(segments)
-    if not selected:
-        raise ValueError("no segments selected")
+def segments_to_mask(segments: Iterable[int], profile: ModelProfile | None = None) -> int:
+    """Validate one-based indices, optionally for a target, and build a 15-bit mask."""
+    if profile is not None and not profile.supports_segments:
+        raise ValueError(f"{profile.name} does not support per-segment control")
+    count = SEGMENT_COUNT if profile is None else min(SEGMENT_COUNT, profile.segment_count)
     mask = 0
-    for segment in selected:
-        if not 1 <= segment <= SEGMENT_COUNT:
-            raise ValueError(f"segment {segment} out of range 1..{SEGMENT_COUNT}")
+    for segment in segments:
+        if not isinstance(segment, int) or isinstance(segment, bool):
+            raise ValueError("segment indices must be integers")
+        if not 1 <= segment <= count:
+            raise ValueError(f"segment {segment} out of range 1..{count}")
         mask |= 1 << (segment - 1)
+    if not mask:
+        raise ValueError("no segments selected")
     return mask
 
 
@@ -44,24 +48,36 @@ def build_segment_color(
     green: int,
     blue: int,
     model: str = "H617A",
+    *,
+    profile: ModelProfile | None = None,
 ) -> bytes:
-    return build_segment_colour(segments_to_mask(segments), red, green, blue, model)
+    return build_segment_colour(segments_to_mask(segments, profile or get_profile(model)), red, green, blue, model)
 
 
 def build_segment_brightness(
     segments: Iterable[int],
     percent: int,
     model: str = "H617A",
+    *,
+    profile: ModelProfile | None = None,
 ) -> bytes:
-    return build_segment_brightness_mask(segments_to_mask(segments), percent, model)
+    return build_segment_brightness_mask(segments_to_mask(segments, profile or get_profile(model)), percent, model)
 
 
 def build_segment_paint(
     groups: Iterable[SegmentColorGroup],
     model: str = "H617A",
+    *,
+    profile: ModelProfile | None = None,
 ) -> list[bytes]:
     """Build one packet for each group because distinct colours require distinct writes."""
-    return [build_segment_color(segments, red, green, blue, model) for segments, (red, green, blue) in groups]
+    packets = [
+        build_segment_color(segments, red, green, blue, model, profile=profile)
+        for segments, (red, green, blue) in groups
+    ]
+    if not packets:
+        raise ValueError("at least one non-empty segment group is required")
+    return packets
 
 
 def build_color_rgb(red: int, green: int, blue: int, model: str = "H617A") -> bytes:
@@ -87,7 +103,7 @@ def build_color_temp(kelvin: int, model: str = "H617A") -> bytes:
 
 
 def build_white_brightness(percent: int, model: str = "H617A") -> bytes:
-    return build_segment_brightness(ALL_SEGMENTS, percent, model)
+    return build_segment_brightness_mask(get_profile(model).whole_device_mask, percent, model)
 
 
 @dataclass(frozen=True)

--- a/custom_components/ha_govee_led_ble/light_services.py
+++ b/custom_components/ha_govee_led_ble/light_services.py
@@ -17,14 +17,25 @@ from .const import DOMAIN
 from .control_arbiter import ControlIntent, async_control_intent
 from .coordinator import GoveeBLECoordinator
 from .generated_protocol_adapter import build_h6199_video, build_power
-from .light_commands import SegmentColorGroup
+from .light_commands import SegmentColorGroup, build_segment_brightness, build_segment_paint, segments_to_mask
 from .native_profile_controls import apply_active_video_mode
 
 __all__ = ("apply_active_video_mode", "async_register_light_services")
 
+
+def _segment(value: int | str) -> int:
+    """Keep integer-string service inputs without truncating fractional indices."""
+    try:
+        if isinstance(value, str):
+            value = int(value)
+        segments_to_mask((value,))
+    except (TypeError, ValueError) as err:
+        raise vol.Invalid(str(err)) from err
+    return value
+
+
 _PERCENTAGE = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
-_SEGMENT = vol.All(vol.Coerce(int), vol.Range(min=1, max=15))
-_SEGMENTS = vol.All([_SEGMENT], vol.Length(min=1))
+_SEGMENTS = vol.All([_segment], vol.Length(min=1))
 _RGB = vol.All(vol.ExactSequence((cv.byte, cv.byte, cv.byte)), vol.Coerce(tuple))
 _PAINT_SEGMENTS_SCHEMA: VolDictType = {
     vol.Required("groups"): vol.All(
@@ -150,61 +161,51 @@ class _GoveeLightServicesMixin(_GoveeLightOwner):
         self._notify_state_changed()
 
     async def async_paint_segments(self, groups: list[dict[str, Any]]) -> None:
-        await self._async_supersede_preview()
-        async with async_control_intent(
-            self.coordinator,
-            ControlIntent.USER,
-        ):
-            self._require_support("paint_segments", supported=self.coordinator.profile.supports_segments)
-            if not groups or any(not group.get("segments") for group in groups):
-                raise ServiceValidationError(
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_segments",
-                )
-            resolved: list[SegmentColorGroup] = [(group["segments"], group["rgb_color"]) for group in groups]
-            try:
+        self._require_support("paint_segments", supported=self.coordinator.profile.supports_segments)
+        try:
+            resolved: list[SegmentColorGroup] = [
+                (list(group.get("segments", [])), group["rgb_color"]) for group in groups
+            ]
+            # Preflight serialization before disturbing an active preview or claiming user control.
+            build_segment_paint(resolved, self.coordinator.model, profile=self.coordinator.profile)
+            await self._async_supersede_preview()
+            async with async_control_intent(self.coordinator, ControlIntent.USER):
                 await self.coordinator.async_paint_segments(resolved)
-            except (TypeError, ValueError) as err:
-                raise ServiceValidationError(
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_segments",
-                ) from err
-            except HomeAssistantError:
-                raise
-            except Exception as err:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="device_command_failed",
-                ) from err
+        except (TypeError, ValueError) as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_segments",
+            ) from err
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="device_command_failed",
+            ) from err
 
     async def async_set_segment_color(self, segments: list[int], color: tuple[int, int, int]) -> None:
         group: dict[str, Any] = {"segments": segments, "rgb_color": color}
         await self.async_paint_segments([group])
 
     async def async_set_segment_brightness(self, segments: list[int], brightness: int) -> None:
-        await self._async_supersede_preview()
-        async with async_control_intent(
-            self.coordinator,
-            ControlIntent.USER,
-        ):
-            self._require_support("set_segment_brightness", supported=self.coordinator.profile.supports_segments)
-            if not segments:
-                raise ServiceValidationError(
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_segments",
-                )
-            try:
+        self._require_support("set_segment_brightness", supported=self.coordinator.profile.supports_segments)
+        try:
+            segments = list(segments)
+            build_segment_brightness(segments, brightness, self.coordinator.model, profile=self.coordinator.profile)
+            await self._async_supersede_preview()
+            async with async_control_intent(self.coordinator, ControlIntent.USER):
                 await self.coordinator.async_set_segment_brightness(segments, brightness)
-            except (TypeError, ValueError) as err:
-                raise ServiceValidationError(
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_segments",
-                ) from err
-            except HomeAssistantError:
-                raise
-            except Exception as err:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="device_command_failed",
-                ) from err
-            self._notify_state_changed()
+                self._notify_state_changed()
+        except (TypeError, ValueError) as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_segments",
+            ) from err
+        except HomeAssistantError:
+            raise
+        except Exception as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="device_command_failed",
+            ) from err

--- a/scripts/kaitai-runtime-outputs.txt
+++ b/scripts/kaitai-runtime-outputs.txt
@@ -3,6 +3,7 @@ command_write.py
 diy_type03.py
 diy_type04.py
 govee_common.py
+govee_segment_page.py
 govee_shared.py
 h6199_command_write.py
 h6199_effect_upload.py

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -1,5 +1,12 @@
+import ast
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import AsyncMock
+
 import pytest
 
+from custom_components.ha_govee_led_ble import const, effect_catalogue
 from custom_components.ha_govee_led_ble.const import (
     CONF_ALWAYS_INCLUDE_CUSTOM_EFFECTS,
     CONF_EFFECT_FAMILIES,
@@ -18,6 +25,10 @@ from custom_components.ha_govee_led_ble.const import (
     resolve_model,
     wire_model,
 )
+from custom_components.ha_govee_led_ble.coordinator import GoveeBLECoordinator
+from custom_components.ha_govee_led_ble.effect_compiler import CompatibilityState, compatibility, compile_music_profile
+from custom_components.ha_govee_led_ble.effect_domain import LibraryItem, MusicProfile
+from custom_components.ha_govee_led_ble.effect_selector import MUSIC_EFFECTS, effect_selector_entries
 
 
 def test_segment_count_and_supports_segments():
@@ -56,6 +67,7 @@ def test_h617a_and_h617e_share_wire_behaviour_but_keep_exact_product_profiles():
     assert resolve_model("H617E") == "H617E"
     assert protocol_model("H617E") == "H617A"
     assert wire_model("H617E") == "H617A"
+    assert h617e.effect_grammar == h617a.effect_grammar == "H617A"
 
 
 def test_h6076_profile_is_basic_and_fail_closed():
@@ -79,6 +91,7 @@ def test_h6076_profile_is_basic_and_fail_closed():
     assert profile.whole_device_mask == 0x007F
     assert wire_model("H6076") == "H617A"
     assert protocol_model("H6076") == "H6076"
+    assert profile.effect_grammar is None
 
 
 def test_setup_required_domains_must_be_readable():
@@ -93,6 +106,7 @@ def test_unknown_models_fail_closed():
     assert resolve_model("H617A-extra") is None
     assert resolve_model("H9999") is None
     assert wire_model("H9999") is None
+    assert UNSUPPORTED_PROFILE.effect_grammar is None
 
 
 def test_effect_family_defaults_and_options():
@@ -126,6 +140,8 @@ def test_model_specific_music_capabilities():
         "shiny",
     )
     assert MODEL_PROFILES["H6199"].music_modes == ("energetic", "rhythm", "spectrum", "rolling")
+    assert MODEL_PROFILES["H617E"].music_modes == MODEL_PROFILES["H617A"].music_modes
+    assert MODEL_PROFILES["H6199"].effect_grammar == "H6199"
     assert MODEL_PROFILES["H617A"].supports_music_color
     assert MODEL_PROFILES["H6199"].supports_music_color
     assert (MODEL_PROFILES["H617A"].music_sensitivity_min, MODEL_PROFILES["H617A"].music_sensitivity_max) == (0, 99)
@@ -133,3 +149,43 @@ def test_model_specific_music_capabilities():
     assert not MODEL_PROFILES["H6199"].supports_white_brightness
     assert not MODEL_PROFILES["H6199"].static_readback_echoes_color
     assert MODEL_PROFILES["H6199"].supports_video_sound_effects
+
+
+async def test_new_encoding_metadata_does_not_enable_music_before_profile_construction(monkeypatch):
+    # Inject after the registry assignment, before profiles are built, in an isolated module.
+    tree = ast.parse(Path(const.__file__).read_text())
+    assignment = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "MUSIC_MODE_SLUGS"
+    )
+    tree.body.insert(tree.body.index(assignment) + 1, ast.parse('MUSIC_MODE_SLUGS["future_mode"] = 5').body[0])
+    namespace = ModuleType("_music_profile_regression")
+    monkeypatch.setitem(sys.modules, namespace.__name__, namespace)
+    exec(compile(ast.fix_missing_locations(tree), const.__file__, "exec"), namespace.__dict__)  # noqa: S102
+    monkeypatch.setitem(const.MUSIC_MODE_SLUGS, "future_mode", 5)
+    monkeypatch.setitem(MUSIC_EFFECTS, "Music: Future Mode", "future_mode")
+
+    for model in ("H617A", "H617E", "H6199"):
+        profile = namespace.MODEL_PROFILES[model]
+        assert profile.music_modes == MODEL_PROFILES[model].music_modes
+        assert "future_mode" not in profile.music_modes
+        monkeypatch.setitem(MODEL_PROFILES, model, profile)
+        assert "future_mode" not in {mode.id for mode in effect_catalogue._native_music_modes(model)}
+        entries = effect_selector_entries(
+            model, frozenset({const.EFFECT_CATEGORY_REACTIVE}), (), prefix_effect_names=False
+        )
+        assert {entry.value for entry in entries} == set(profile.music_modes)
+        item = LibraryItem.new("Unenabled", MusicProfile(model, "future_mode", 50))
+        assert compatibility(item, model).state is CompatibilityState.INCOMPATIBLE
+        with pytest.raises(ValueError, match="does not support music mode"):
+            compile_music_profile(item, model)
+        coordinator = GoveeBLECoordinator.__new__(GoveeBLECoordinator)
+        coordinator.model = model
+        coordinator.profile = profile
+        coordinator.send_command = AsyncMock()
+        with pytest.raises(ValueError, match="music mode"):
+            await coordinator.async_select_music_slug("future_mode")
+        coordinator.send_command.assert_not_awaited()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1805,6 +1805,66 @@ def test_segment_colors_empty_for_unsupported(hass):
     assert c.segment_colors == [] and c.profile.segment_count == 0
 
 
+@pytest.mark.parametrize("buffered", [False, True])
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"num_segments": None},
+        {"num_segments": "3"},
+        {"num_segments": 3.0},
+        {"num_segments": True},
+        {"num_segments": 0},
+        {"num_segments": 2},
+        {"num_segments": 4},
+        {"group": 0},
+        {"group": 6},
+        {"group": True},
+        {"group": "1"},
+        {"segments": []},
+        {"segments": None},
+        {"segments": [SimpleNamespace(), SimpleNamespace(), SimpleNamespace()]},
+    ],
+)
+def test_segment_page_rejected_before_buffer_mutation(coord, buffered, bad):
+    parsed = parse_status(bytes.fromhex("aaa50164ff880d64ff880d64ff880d0000000010"))
+    assert parsed is not None
+    if buffered:
+        assert coord._apply_segment_group(parsed) == ()
+    colours = coord._segment_query_colors
+    brightness = coord._segment_query_brightness
+    before_colours = list(colours) if colours is not None else None
+    before_brightness = list(brightness) if brightness is not None else None
+    before_groups = set(coord._segment_groups_observed)
+    body = SimpleNamespace(group=1, segments=parsed.body.segments, num_segments=3)
+    vars(body).update(bad)
+    # None also exercises an absent generated cardinality declaration.
+    if bad.get("num_segments", 3) is None:
+        del body.num_segments
+    with pytest.raises(ValueError):
+        coord._apply_segment_group(SimpleNamespace(body=body))
+    assert coord._segment_query_colors is colours
+    assert coord._segment_query_brightness is brightness
+    assert coord._segment_query_colors == before_colours
+    assert coord._segment_query_brightness == before_brightness
+    assert coord._segment_groups_observed == before_groups
+    assert coord.segment_state_source == "initial"
+    assert coord.segment_colors == [(255, 255, 255)] * 15
+
+
+def test_duplicate_segment_pages_require_fresh_complete_coverage(coord):
+    _send_uniform_segment_replies(coord, (10, 20, 30))
+    observed_at = coord.segment_state_observed_at
+    revision = coord._field_revisions["segment_colors"]
+    for group in (1, 1, 2, 3, 4, 4):
+        coord._notify_callback(None, bytearray(proto.build_packet(0xAA, 0xA5, [group, *([50, 1, 2, 3] * 3)])))
+    assert coord._field_revisions["segment_colors"] == revision
+    assert coord.segment_state_observed_at == observed_at
+    assert coord.segment_colors == [(10, 20, 30)] * 15
+    coord._notify_callback(None, bytearray(proto.build_packet(0xAA, 0xA5, [5, *([50, 1, 2, 3] * 3)])))
+    assert coord._field_revisions["segment_colors"] == revision + 1
+    assert coord.segment_colors == [(1, 2, 3)] * 15
+
+
 def test_h6199_static_reply_reports_mode_only(h6199):
     h6199.segment_colors = [(1, 2, 3)] * 15
     h6199._notify_callback(None, bytearray(proto.build_packet(0xAA, 0x05, [0x15, 0x01, 10, 20, 30])))
@@ -1889,16 +1949,16 @@ def test_segment_query_replies_replace_restored_state(
 
 
 async def test_async_paint_segments_updates_slots_and_sends(coord):
-    groups = [([1, 2], (255, 0, 0)), ([3], (0, 0, 255))]
+    groups = [([1, 2, 2], (255, 0, 0)), ([2, 3], (0, 0, 255))]
     with (
         patch.object(coord, "send_command", new_callable=AsyncMock) as sc,
         patch.object(coord, "async_refresh_segments", new_callable=AsyncMock, return_value=True) as refresh,
         patch.object(coord, "async_set_updated_data") as pushed,
     ):
-        await coord.async_paint_segments(groups)
+        await coord.async_paint_segments((iter(segments), rgb) for segments, rgb in groups)
     assert [call.args[0] for call in sc.await_args_list] == proto.build_segment_paint(groups)
     assert sc.await_count == 2
-    assert coord.segment_colors[:4] == [(255, 0, 0), (255, 0, 0), (0, 0, 255), (255, 255, 255)]
+    assert coord.segment_colors[:4] == [(255, 0, 0), (0, 0, 255), (0, 0, 255), (255, 255, 255)]
     assert coord.segment_state_source == "optimistic"
     refresh.assert_awaited_once_with()
     pushed.assert_called_once()
@@ -1916,11 +1976,15 @@ async def test_async_paint_segments_rolls_back_on_failure(coord):
 
 
 async def test_async_set_segment_brightness_verifies_complete_state(coord):
+    def write(_packet):
+        assert coord.segment_brightness == [100] * 15
+        assert coord.segment_state_source == "initial"
+
     with (
-        patch.object(coord, "send_command", new_callable=AsyncMock) as send,
+        patch.object(coord, "send_command", new=AsyncMock(side_effect=write)) as send,
         patch.object(coord, "async_refresh_segments", new_callable=AsyncMock, return_value=True) as refresh,
     ):
-        await coord.async_set_segment_brightness([2, 4], 60)
+        await coord.async_set_segment_brightness(iter([2, 4, 4]), 60)
 
     send.assert_awaited_once_with(build_segment_brightness([2, 4], 60))
     assert coord.segment_brightness[:5] == [100, 60, 100, 60, 100]
@@ -1938,7 +2002,7 @@ async def test_async_paint_segments_rejects_unsupported(coord):
     sc.assert_not_awaited()
 
 
-@pytest.mark.parametrize("bad", [[0], [16], []])
+@pytest.mark.parametrize("bad", [[0], [16], [], [1, True], [1, 1.0], [1.5]])
 async def test_async_paint_segments_rejects_invalid_segments(coord, bad):
     before = list(coord.segment_colors)
     with (
@@ -1948,6 +2012,49 @@ async def test_async_paint_segments_rejects_invalid_segments(coord, bad):
         await coord.async_paint_segments([(bad, (1, 2, 3))])
     sc.assert_not_awaited()
     assert coord.segment_colors == before
+
+
+@pytest.mark.parametrize("count", [5, 14])
+async def test_segment_writes_use_effective_profile(coord, count):
+    coord.profile = replace(coord.profile, segment_count=count)
+    coord.segment_colors = coord.segment_colors[:count]
+    coord.segment_brightness = coord.segment_brightness[:count]
+    with (
+        patch.object(coord, "send_command", new_callable=AsyncMock) as send,
+        patch.object(coord, "async_refresh_segments", new_callable=AsyncMock),
+    ):
+        await coord.async_paint_segments([([count], (1, 2, 3))])
+        await coord.async_set_segment_brightness([count], 50)
+        assert send.await_count == 2
+        send.reset_mock()
+        with patch.object(coord, "mark_segment_state_optimistic") as optimistic:
+            with pytest.raises(ValueError):
+                await coord.async_paint_segments([([1], (4, 5, 6)), ([count + 1], (1, 2, 3))])
+            with pytest.raises(ValueError):
+                await coord.async_set_segment_brightness([count + 1], 50)
+        optimistic.assert_not_called()
+        send.assert_not_awaited()
+    assert coord.segment_colors == [(255, 255, 255)] * (count - 1) + [(1, 2, 3)]
+    assert coord.segment_brightness == [100] * (count - 1) + [50]
+
+
+async def test_paint_serialization_failure_precedes_optimistic_state(coord):
+    before = list(coord.segment_colors)
+    with (
+        patch(
+            "custom_components.ha_govee_led_ble.generated_protocol_adapter._serialize_xor",
+            side_effect=[b"first packet", ValueError("serialization failed")],
+        ) as serialize,
+        patch.object(coord, "mark_segment_state_optimistic") as optimistic,
+        patch.object(coord, "send_command", new_callable=AsyncMock) as send,
+        pytest.raises(ValueError, match="serialization failed"),
+    ):
+        await coord.async_paint_segments([([1], (1, 2, 3)), ([2], (4, 5, 6))])
+    assert serialize.call_count == 2
+    optimistic.assert_not_called()
+    send.assert_not_awaited()
+    assert coord.segment_colors == before
+    assert coord.segment_state_source == "initial"
 
 
 async def test_native_scene_primitive_acquires_control_lock_exactly_once(coord):

--- a/tests/test_coordinator_status.py
+++ b/tests/test_coordinator_status.py
@@ -66,6 +66,25 @@ def test_identity_versions_decode_for_both_models() -> None:
     assert h6199_hardware is not None and h6199_hardware.generated.body.text == "3.02.01"
 
 
+@pytest.mark.parametrize("model", ["H617A", "H617E"])
+def test_production_three_record_status_contract(model: str) -> None:
+    frame = bytearray(H("aaa50164ff880d64ff880d64ff880d0000000010"))
+    for group in range(1, 6):
+        frame[2] = group
+        frame[-1] = xor_checksum(frame[:-1])
+        decoded = decode_status_frame(bytes(frame), model)
+        assert decoded is not None
+        assert decoded.generated.body.num_segments == len(decoded.generated.body.segments) == 3
+        assert decoded.generated.body.unused == [0] * 4
+    for group in (0, 6):
+        frame[2] = group
+        frame[-1] = xor_checksum(frame[:-1])
+        assert decode_status_frame_result(bytes(frame), model).rejection is ProtocolParseRejection.SCHEMA_REJECTED
+    issue_frame = H("aaa50164e5444464ffae5464ffae5464cf2e2e24")
+    assert decode_status_frame_result(issue_frame, model).rejection is ProtocolParseRejection.SCHEMA_REJECTED
+    assert decode_status_frame_result(issue_frame, "H66A0").rejection is ProtocolParseRejection.UNSUPPORTED_MODEL
+
+
 def test_h617a_colour_modes_preserve_scene_diy_and_music_semantics() -> None:
     scene = _parse_colour("aa05049d0800000000000000000000000000003e")
     assert scene.mode is ParsedMode.SCENE and scene.effect == "candy"

--- a/tests/test_diy_protocol.py
+++ b/tests/test_diy_protocol.py
@@ -1,11 +1,14 @@
 """Round-trip tests for H617A DIY body encoders."""
 
 import io
+from dataclasses import replace
 
 import pytest
 from kaitaistruct import KaitaiStream
 
 from custom_components.ha_govee_led_ble import effect_commands as proto
+from custom_components.ha_govee_led_ble import effect_contracts
+from custom_components.ha_govee_led_ble.const import MODEL_PROFILES, ModelProfile
 from custom_components.ha_govee_led_ble.effect_catalogue import (
     H617A_TYPE04_APPLY_CODE,
     H6199_DIY_EFFECTS,
@@ -13,9 +16,16 @@ from custom_components.ha_govee_led_ble.effect_catalogue import (
     WORKSHOP_PROTOCOL_FIXTURES,
 )
 from custom_components.ha_govee_led_ble.effect_compiler import (
+    CompatibilityState,
+    compatibility,
     compile_effect,
     compile_h617a,
     compile_h6199,
+)
+from custom_components.ha_govee_led_ble.effect_contracts import (
+    ApplicationRoute,
+    CapabilityWorkflow,
+    release_capability,
 )
 from custom_components.ha_govee_led_ble.effect_domain import (
     EffectPair,
@@ -29,6 +39,7 @@ from custom_components.ha_govee_led_ble.effect_protocol_decoder import (
     UnsupportedA3EffectError,
     decode_a3_effect,
 )
+from custom_components.ha_govee_led_ble.effect_runtime import resolve_diy_code
 from custom_components.ha_govee_led_ble.generated_protocol.diy_type03 import DiyType03
 from custom_components.ha_govee_led_ble.generated_protocol.diy_type04 import DiyType04
 from custom_components.ha_govee_led_ble.generated_protocol.h6199_effect_upload import H6199EffectUpload
@@ -37,7 +48,8 @@ from custom_components.ha_govee_led_ble.generated_protocol_adapter import (
     parse_a3_effect_envelope,
     parse_command,
 )
-from custom_components.ha_govee_led_ble.transport import reassemble_a3
+from custom_components.ha_govee_led_ble.layered_scene_decoder import decode_workshop_effect, encode_workshop_effect
+from custom_components.ha_govee_led_ble.transport import fragment_a3, reassemble_a3
 
 H = bytes.fromhex
 
@@ -259,7 +271,7 @@ def test_basic_effect_decoder_rejects_uncatalogued_and_reserved_values() -> None
         decode_a3_effect(h6199, "H6199")
 
 
-@pytest.mark.parametrize("model", ["H617A", "H6199"])
+@pytest.mark.parametrize("model", ["H617A", "H617E", "H6199"])
 def test_workshop_upload_tree_reuses_lossless_layered_decoder(model: str) -> None:
     workshop = WORKSHOP_PROTOCOL_FIXTURES[0].content(model)
     compiled = compile_effect(LibraryItem.new("Workshop", workshop), model)
@@ -268,6 +280,126 @@ def test_workshop_upload_tree_reuses_lossless_layered_decoder(model: str) -> Non
     parsed = parse_a3_effect_envelope(envelope, model)
 
     assert decode_a3_effect(parsed, model) == workshop.effect
+
+
+@pytest.mark.parametrize("grammar", ["H617A", "H6199"])
+def test_profile_effect_grammar_enables_codecs_without_authorizing_application(monkeypatch, grammar) -> None:
+    model = "H9999"
+    monkeypatch.setitem(MODEL_PROFILES, model, ModelProfile("Synthetic", effect_grammar=grammar))
+    workshop = WORKSHOP_PROTOCOL_FIXTURES[0].content(grammar)
+    payload = encode_workshop_effect(model, workshop.effect, trailing_padding=workshop.trailing_padding)
+    assert payload == workshop.raw_param
+    assert decode_workshop_effect(model, payload) == (workshop.effect, workshop.trailing_padding)
+    envelope = reassemble_a3(fragment_a3(2, payload))
+    parsed = parse_a3_effect_envelope(envelope, model)
+    assert decode_a3_effect(parsed, model) == workshop.effect
+
+    item = LibraryItem.new("Synthetic", replace(workshop, model=model))
+    assert compatibility(item, model).state is CompatibilityState.INCOMPATIBLE
+    with pytest.raises(ValueError, match="Workshop application is not supported"):
+        compile_effect(item, model)
+    with pytest.raises(ValueError, match="Workshop application is not supported"):
+        resolve_diy_code(item)
+
+    # Existing workflow authorization and the matching command route are separate evidence.
+    capability = release_capability(grammar, CapabilityWorkflow.WORKSHOP)
+    assert capability is not None
+    monkeypatch.setattr(
+        effect_contracts,
+        "RELEASE_CAPABILITY_CONTRACT",
+        (*effect_contracts.RELEASE_CAPABILITY_CONTRACT, replace(capability, model=model)),
+    )
+    with pytest.raises(ValueError, match="activation route"):
+        compile_effect(item, model)
+    monkeypatch.setitem(MODEL_PROFILES, model, replace(MODEL_PROFILES[model], wire_model=grammar))
+    compiled = compile_effect(item, model)
+    reference = compile_effect(LibraryItem.new("Reference", workshop), grammar)
+    assert compiled.model == model
+    assert compiled.packets == reference.packets
+    assert resolve_diy_code(item) == reference.diy_code
+
+
+@pytest.mark.parametrize("model", ["H6076", "H9999"])
+def test_basic_wire_alias_does_not_supply_effect_grammar(monkeypatch, model) -> None:
+    if model == "H9999":
+        monkeypatch.setitem(MODEL_PROFILES, model, ModelProfile("Synthetic", wire_model="H617A"))
+    workshop = WORKSHOP_PROTOCOL_FIXTURES[0].content("H617A")
+    envelope = reassemble_a3(fragment_a3(2, workshop.raw_param))
+    parsed = parse_a3_effect_envelope(envelope, "H617A")
+    with pytest.raises(ValueError, match="no generated A3 effect grammar"):
+        parse_a3_effect_envelope(envelope, model)
+    with pytest.raises(ValueError, match="no canonical A3 effect decoder"):
+        decode_a3_effect(parsed, model)
+    with pytest.raises(ValueError, match="no Workshop grammar"):
+        decode_workshop_effect(model, workshop.raw_param)
+    with pytest.raises(ValueError, match="no Workshop grammar"):
+        encode_workshop_effect(model, workshop.effect)
+    item = LibraryItem.new("Unsupported", replace(workshop, model=model))
+    assert compatibility(item, model).state is CompatibilityState.INCOMPATIBLE
+    with pytest.raises(ValueError, match="Workshop application is not supported"):
+        compile_effect(item, model)
+    with pytest.raises(ValueError, match="Workshop application is not supported"):
+        resolve_diy_code(item)
+
+
+@pytest.mark.parametrize("grammar", [None, "unknown"])
+def test_workshop_authorization_without_supported_grammar_is_rejected(monkeypatch, grammar) -> None:
+    item = LibraryItem.new("Workshop", WORKSHOP_PROTOCOL_FIXTURES[0].content("H617A"))
+    monkeypatch.setitem(MODEL_PROFILES, "H617A", replace(MODEL_PROFILES["H617A"], effect_grammar=grammar))
+    assert compatibility(item, "H617A").state is CompatibilityState.INCOMPATIBLE
+    with pytest.raises(ValueError, match="activation route"):
+        compile_effect(item, "H617A")
+    with pytest.raises(ValueError, match="activation route"):
+        resolve_diy_code(item)
+
+
+def test_workshop_grammar_cannot_bypass_disabled_workflow(monkeypatch) -> None:
+    item = LibraryItem.new("Workshop", WORKSHOP_PROTOCOL_FIXTURES[0].content("H617A"))
+    monkeypatch.setattr(
+        effect_contracts,
+        "RELEASE_CAPABILITY_CONTRACT",
+        tuple(
+            replace(capability, application_route=ApplicationRoute.NONE)
+            if capability.workflow is CapabilityWorkflow.WORKSHOP
+            else capability
+            for capability in effect_contracts.RELEASE_CAPABILITY_CONTRACT
+        ),
+    )
+    assert compatibility(item, "H617A").state is CompatibilityState.INCOMPATIBLE
+    with pytest.raises(ValueError, match="Workshop application is not supported"):
+        compile_effect(item, "H617A")
+    with pytest.raises(ValueError, match="Workshop application is not supported"):
+        resolve_diy_code(item)
+
+
+def test_h617e_workshop_preserves_exact_identity_and_h617a_bytes() -> None:
+    workshop = WORKSHOP_PROTOCOL_FIXTURES[0].content("H617E")
+    item = LibraryItem.new("H617E", workshop)
+    compiled = compile_effect(item, "H617E")
+    reference = compile_effect(LibraryItem.new("H617A", replace(workshop, model="H617A")), "H617A")
+    assert workshop.model == compiled.model == "H617E"
+    assert compiled.packets == reference.packets
+    assert resolve_diy_code(item) == reference.diy_code
+    with pytest.raises(ValueError, match="targets H617E"):
+        compile_effect(item, "H617A")
+
+
+@pytest.mark.parametrize(
+    ("grammar", "content"),
+    [("H617A", PAINTED_CONTENT), ("H617A", SINGLE_CONTENT), ("H617A", MULTI_CONTENT), ("H6199", H6199_CONTENT)],
+)
+def test_profile_grammar_selects_basic_canonical_semantics(monkeypatch, grammar, content) -> None:
+    monkeypatch.setitem(MODEL_PROFILES, "H9999", ModelProfile("Synthetic", effect_grammar=grammar))
+    item = LibraryItem.new("Reference", content)
+    compiled = compile_effect(item, grammar, diy_code=800 if grammar == "H617A" else None)
+    envelope = reassemble_a3(compiled.upload_packets)
+    for model in ("H9999", "H617E") if grammar == "H617A" else ("H9999",):
+        expected = replace(content, model=model) if isinstance(content, PaletteDiyEffect) else content
+        assert decode_a3_effect(parse_a3_effect_envelope(envelope, model), model) == expected
+        if model == "H9999":
+            assert compatibility(LibraryItem.new("Decoded", expected), model).state is CompatibilityState.INCOMPATIBLE
+    if grammar == "H617A":
+        assert compile_effect(item, "H617E", diy_code=800).packets == compiled.packets
 
 
 @pytest.mark.parametrize("effect", ["", "unknown", "Clockwise"])

--- a/tests/test_effect_runtime.py
+++ b/tests/test_effect_runtime.py
@@ -1387,7 +1387,7 @@ async def test_h6199_uncertain_result_emits_structured_evidence_gap(
     }
 
 
-@pytest.mark.parametrize("model", ["H617A", "H6199"])
+@pytest.mark.parametrize("model", ["H617A", "H617E", "H6199"])
 async def test_workshop_uses_evidenced_model_application(
     hass: HomeAssistant,
     model: str,
@@ -1415,15 +1415,22 @@ async def test_workshop_uses_evidenced_model_application(
     assert cache.get("entry-a").diy_code == workshop_code
 
 
-async def test_cross_model_workshop_is_rejected_before_any_write(
+@pytest.mark.parametrize(
+    ("target", "source", "reason"),
+    [("H6199", "H617A", "targets H617A"), ("H6076", "H6076", "Workshop application is not supported")],
+)
+async def test_incompatible_workshop_is_rejected_before_any_write(
     hass: HomeAssistant,
+    target: str,
+    source: str,
+    reason: str,
 ) -> None:
     repository, cache = await _repositories(hass)
     coordinator = _coordinator()
-    coordinator.model = "H6199"
-    item = LibraryItem.new("Workshop", WORKSHOP_PROTOCOL_FIXTURES[0].content("H617A"))
+    coordinator.model = target
+    item = LibraryItem.new("Workshop", replace(WORKSHOP_PROTOCOL_FIXTURES[0].content("H617A"), model=source))
 
-    with pytest.raises(ValueError, match="targets H617A"):
+    with pytest.raises(ValueError, match=reason):
         await EffectDeploymentEngine(repository, cache).async_apply_saved(
             coordinator,
             item,

--- a/tests/test_kaitai_protocol.py
+++ b/tests/test_kaitai_protocol.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import io
 import os
 import sys
+from dataclasses import replace
 from importlib import import_module
 from typing import Any
 
 import pytest
 from kaitaistruct import KaitaiStream, KaitaiStructError
+
+from custom_components.ha_govee_led_ble import generated_protocol_adapter
+from custom_components.ha_govee_led_ble.const import MODEL_PROFILES
+from custom_components.ha_govee_led_ble.coordinator import GoveeBLECoordinator
+from custom_components.ha_govee_led_ble.transport import xor_checksum
 
 _GENERATED_DIR = os.environ.get("KAITAI_GENERATED_DIR")
 if _GENERATED_DIR:
@@ -132,6 +138,94 @@ def test_command_and_status_fields_are_meaningful() -> None:
     h6199_query = _parse(H6199StatusQuery, H6199_SEGMENT_QUERY)
     assert (h617a_query.domain.name, h617a_query.body.group) == ("segments", 5)
     assert (h6199_query.domain.name, h6199_query.body.group) == ("segments", 4)
+
+
+@pytest.mark.parametrize("group", [1, 2, 3, 4])
+def test_h6199_segment_pages_preserve_opaque_tail(group: int) -> None:
+    records = bytes.fromhex("00000000 64010203 32112233 27abcdef")
+    frame = bytes((0xAA, 0xA5, group)) + records
+    frame += bytes((xor_checksum(frame),))
+    parsed = _parse(H6199StatusReply, frame)
+    expected_count = 3 if group == 4 else 4
+    assert parsed.body.num_segments == len(parsed.body.segments) == expected_count
+    assert parsed.body.segments[0].brightness == 0
+    assert parsed.body.unused == (list(records[-4:]) if group == 4 else [])
+    parsed._fetch_instances()
+    parsed._check()
+    output = KaitaiStream(io.BytesIO(bytes(20)))
+    parsed._write(output)
+    assert output.to_byte_array() == frame
+
+
+@pytest.mark.skipif(not _GENERATED_DIR, reason="H66A0 is an all-schema fixture, not a runtime root")
+def test_h66a0_four_slot_pages_reach_semantic_observation(hass, monkeypatch) -> None:
+    root = _generated("h66a0_status_reply", "H66a0StatusReply")
+    first = bytes.fromhex("aaa50164e5444464ffae5464ffae5464cf2e2e24")
+    final = bytes.fromhex("aaa50464dc3b3b64e54444000000000000000032")
+    # Pages 2/3 are synthetic, including a meaningful black/off segment.
+    second = bytes.fromhex("aaa502 00000000 01010203 02040506 03070809")
+    second += bytes((xor_checksum(second),))
+    third = bytes.fromhex("aaa503 040a0b0c 050d0e0f 06101112 07131415")
+    third += bytes((xor_checksum(third),))
+    for frame, count in ((first, 4), (second, 4), (third, 4), (final, 2)):
+        parsed = _parse(root, frame)
+        assert parsed.body.num_segments == len(parsed.body.segments) == count
+        assert len(parsed.body.segments) * 4 + len(parsed.body.unused) == 16
+        parsed._fetch_instances()
+        parsed._check()
+        output = KaitaiStream(io.BytesIO(bytes(20)))
+        parsed._write(output)
+        assert output.to_byte_array() == frame
+
+    # Unused slots are opaque, not a zero constraint or extra semantic records.
+    nonzero_final = final[:11] + bytes.fromhex("deadbeef 12345678")
+    nonzero_final += bytes((xor_checksum(nonzero_final),))
+    parsed = _parse(root, nonzero_final)
+    assert parsed.body.unused == list(bytes.fromhex("deadbeef12345678"))
+    parsed._fetch_instances()
+    parsed._check()
+    output = KaitaiStream(io.BytesIO(bytes(20)))
+    parsed._write(output)
+    assert output.to_byte_array() == nonzero_final
+
+    # Test-only layout selection exercises real decode/notify/observation without
+    # registering H66A0 or changing the production status dispatcher.
+    profile = replace(MODEL_PROFILES["H617A"], segment_count=14, segment_group_size=4)
+    monkeypatch.setattr("custom_components.ha_govee_led_ble.coordinator.get_profile", lambda _: profile)
+    monkeypatch.setitem(generated_protocol_adapter._STATUS_ROOTS, "H617A", ("h66a0_status_reply", root))
+    coordinator = GoveeBLECoordinator(
+        hass, "AA:BB:CC:DD:EE:FF", "H617A", configuration_url="homeassistant://ha-govee-led-ble/editor/test"
+    )
+    for frame in (final, first, first, third):
+        coordinator._notify_callback(None, bytearray(frame))
+        assert coordinator.segment_state_source == "initial"
+        assert coordinator._field_revisions.get("segment_colors", 0) == 0
+    coordinator._notify_callback(None, bytearray(second))
+    assert coordinator.segment_state_source == "observed"
+    assert coordinator.segment_state_observed_at is not None
+    assert coordinator._field_revisions["segment_colors"] == 1
+    assert coordinator.segment_brightness == [100] * 4 + list(range(8)) + [100, 100]
+    assert coordinator.segment_colors == [
+        (229, 68, 68),
+        (255, 174, 84),
+        (255, 174, 84),
+        (207, 46, 46),
+        (0, 0, 0),
+        (1, 2, 3),
+        (4, 5, 6),
+        (7, 8, 9),
+        (10, 11, 12),
+        (13, 14, 15),
+        (16, 17, 18),
+        (19, 20, 21),
+        (220, 59, 59),
+        (229, 68, 68),
+    ]
+    for frame in (nonzero_final, first, second, third):
+        coordinator._notify_callback(None, bytearray(frame))
+    assert coordinator._field_revisions["segment_colors"] == 2
+    assert len(coordinator.segment_colors) == len(coordinator.segment_brightness) == 14
+    assert coordinator.segment_colors[-2:] == [(220, 59, 59), (229, 68, 68)]
 
 
 def test_diy_shapes_expose_painted_flat_and_combo_fields() -> None:

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+import voluptuous as vol
 from bleak import BleakError
 from homeassistant.components.light import ColorMode
 from homeassistant.core import HomeAssistant
@@ -66,7 +67,7 @@ from custom_components.ha_govee_led_ble.light_commands import (
     build_color_temp,
     kelvin_to_rgb,
 )
-from custom_components.ha_govee_led_ble.light_services import async_register_light_services
+from custom_components.ha_govee_led_ble.light_services import _SEGMENTS, async_register_light_services
 from custom_components.ha_govee_led_ble.native_scenes import build_native_scene_packets
 from custom_components.ha_govee_led_ble.scenes import MODEL_SCENE_LABELS, MODEL_SCENES, SCENES
 from tests.storage_test_double import InMemoryVersionedDocumentStore
@@ -1267,6 +1268,14 @@ def test_registers_segment_services_during_integration_setup():
     }
 
 
+def test_segment_service_schema_preserves_integer_strings_only():
+    schema = vol.Schema(_SEGMENTS)
+    assert schema(["1", "15", 2, "2"]) == [1, 15, 2, 2]
+    for invalid in ([], [0], [16], [True], [False], [1.5], [1.0], ["1.5"]):
+        with pytest.raises(vol.Invalid):
+            schema(invalid)
+
+
 async def test_setup_entry_adds_light(mock_coordinator):
     entry = MagicMock(runtime_data=mock_coordinator)
     added: list = []
@@ -1284,9 +1293,72 @@ async def test_setup_entry_adds_light(mock_coordinator):
     ],
 )
 async def test_segment_services_reject_empty_selections(light, mock_coordinator, method, kwargs):
-    with pytest.raises(ServiceValidationError) as exc:
+    with (
+        patch.object(light, "_async_supersede_preview", new_callable=AsyncMock) as preview,
+        patch("custom_components.ha_govee_led_ble.light_services.async_control_intent") as intent,
+        pytest.raises(ServiceValidationError) as exc,
+    ):
         await getattr(light, method)(**kwargs)
     assert exc.value.translation_key == "invalid_segments"
+    preview.assert_not_awaited()
+    intent.assert_not_called()
+    mock_coordinator.send_command.assert_not_awaited()
+
+
+@pytest.mark.parametrize("count", [5, 14])
+@pytest.mark.parametrize("method", ["async_paint_segments", "async_set_segment_color", "async_set_segment_brightness"])
+async def test_segment_service_preflight_uses_effective_profile(light, mock_coordinator, count, method):
+    mock_coordinator.profile = replace(mock_coordinator.profile, segment_count=count)
+    for index in (count, count + 1, True, 1.5):
+        if method == "async_paint_segments":
+            kwargs = {
+                "groups": [{"segments": [1], "rgb_color": (4, 5, 6)}, {"segments": [index], "rgb_color": (1, 2, 3)}]
+            }
+        elif method == "async_set_segment_color":
+            kwargs = {"segments": [index], "color": (1, 2, 3)}
+        else:
+            kwargs = {"segments": [index], "brightness": 50}
+        if index == count:
+            await getattr(light, method)(**kwargs)
+            mock_coordinator.async_paint_segments.reset_mock()
+            mock_coordinator.async_set_segment_brightness.reset_mock()
+            continue
+        with (
+            patch.object(light, "_async_supersede_preview", new_callable=AsyncMock) as preview,
+            patch("custom_components.ha_govee_led_ble.light_services.async_control_intent") as intent,
+            pytest.raises(ServiceValidationError) as exc,
+        ):
+            await getattr(light, method)(**kwargs)
+        assert exc.value.translation_key == "invalid_segments"
+        preview.assert_not_awaited()
+        intent.assert_not_called()
+        mock_coordinator.async_paint_segments.assert_not_awaited()
+        mock_coordinator.async_set_segment_brightness.assert_not_awaited()
+        mock_coordinator.mark_segment_state_optimistic.assert_not_called()
+        mock_coordinator.send_command.assert_not_awaited()
+
+
+async def test_paint_service_serialization_failure_preserves_preview(light, mock_coordinator):
+    with (
+        patch(
+            "custom_components.ha_govee_led_ble.generated_protocol_adapter._serialize_xor",
+            side_effect=[b"first packet", ValueError("serialization failed")],
+        ) as serialize,
+        patch.object(light, "_async_supersede_preview", new_callable=AsyncMock) as preview,
+        patch("custom_components.ha_govee_led_ble.light_services.async_control_intent") as intent,
+        pytest.raises(ServiceValidationError),
+    ):
+        await light.async_paint_segments(
+            [
+                {"segments": [1], "rgb_color": (1, 2, 3)},
+                {"segments": [2], "rgb_color": (4, 5, 6)},
+            ]
+        )
+    assert serialize.call_count == 2
+    preview.assert_not_awaited()
+    intent.assert_not_called()
+    mock_coordinator.async_paint_segments.assert_not_awaited()
+    mock_coordinator.mark_segment_state_optimistic.assert_not_called()
     mock_coordinator.send_command.assert_not_awaited()
 
 
@@ -1317,6 +1389,12 @@ async def test_segment_colour_services_normalise_groups(
     kwargs,
     expected,
 ):
+    if method == "async_paint_segments":
+        kwargs["groups"] = (
+            {"segments": iter(group["segments"]), "rgb_color": group["rgb_color"]} for group in kwargs["groups"]
+        )
+    else:
+        kwargs["segments"] = iter(kwargs["segments"])
     await getattr(light, method)(**kwargs)
 
     mock_coordinator.async_paint_segments.assert_awaited_once_with(expected)
@@ -1342,7 +1420,7 @@ async def test_segment_service_wraps_transport_failure(light, mock_coordinator):
 
 async def test_set_segment_brightness_sends_packet(light, mock_coordinator):
     light.async_write_ha_state = MagicMock()
-    await light.async_set_segment_brightness(segments=[2, 4], brightness=60)
+    await light.async_set_segment_brightness(segments=iter([2, 4]), brightness=60)
     mock_coordinator.async_set_segment_brightness.assert_awaited_once_with([2, 4], 60)
     light.async_write_ha_state.assert_called_once_with()
 

--- a/tests/test_light_commands.py
+++ b/tests/test_light_commands.py
@@ -1,7 +1,10 @@
 """Semantic light-command tests."""
 
+from dataclasses import replace
+
 import pytest
 
+from custom_components.ha_govee_led_ble.const import MODEL_PROFILES
 from custom_components.ha_govee_led_ble.generated_protocol_adapter import build_brightness, build_power
 from custom_components.ha_govee_led_ble.light_commands import (
     ALL_SEGMENTS,
@@ -50,6 +53,8 @@ def test_h6076_uses_its_whole_device_mask_and_kelvin_range() -> None:
     assert parsed is not None and parsed.whole_strip
     assert build_color_temp(2000, "H6076")[7:9] == (2700).to_bytes(2, "big")
     assert build_color_temp(9000, "H6076")[7:9] == (6500).to_bytes(2, "big")
+    assert build_color_temp(4000, "H6076")[12:14] == b"\x7f\x00"
+    assert build_white_brightness(50, "H6076") == H("33051502327f000000000000000000000000006c")
 
 
 def test_segment_numbering_and_masks() -> None:
@@ -57,7 +62,8 @@ def test_segment_numbering_and_masks() -> None:
     assert segments_to_mask([3]) == 0x0004
     assert segments_to_mask([15]) == 0x4000
     assert segments_to_mask(ALL_SEGMENTS) == ALL_SEGMENTS_MASK
-    for invalid in ([], [0], [16], [-1], [1, 16]):
+    assert segments_to_mask(iter([1, 1, 3])) == 0x0005
+    for invalid in ([], [0], [16], [-1], [1, 16], [1, True], [1, 1.0], [1.5], ["1"]):
         with pytest.raises(ValueError):
             segments_to_mask(invalid)
 
@@ -74,6 +80,41 @@ def test_segment_commands_and_paint_order() -> None:
     ]
     _assert_valid(colour)
     _assert_valid(brightness)
+
+
+@pytest.mark.parametrize("count", [5, 14])
+def test_segment_builders_validate_effective_profile(count):
+    profile = replace(MODEL_PROFILES["H617A"], segment_count=count)
+    for selected in ([count], [count + 1]):
+        builders = (
+            lambda selected=selected: build_segment_color(iter(selected), 1, 2, 3, profile=profile),
+            lambda selected=selected: build_segment_brightness(iter(selected), 50, profile=profile),
+            lambda selected=selected: build_segment_paint(iter([(iter(selected), (1, 2, 3))]), profile=profile)[0],
+        )
+        for build in builders:
+            if selected == [count]:
+                parsed = parse_static_write(build())
+                assert parsed is not None and parsed.segment_mask == 1 << (count - 1)
+            else:
+                with pytest.raises(ValueError, match=f"1..{count}"):
+                    build()
+
+
+@pytest.mark.parametrize("model", ["H6076", "H617A"])
+def test_segment_builders_require_segment_capability(model):
+    profile = replace(MODEL_PROFILES[model], supports_segment_writes=False)
+    for build, args in (
+        (build_segment_color, ([1], 1, 2, 3)),
+        (build_segment_brightness, ([1], 50)),
+        (build_segment_paint, ([([1], (1, 2, 3))],)),
+    ):
+        with pytest.raises(ValueError, match="per-segment control"):
+            build(*args, model=model, profile=profile)
+        if model == "H6076":
+            with pytest.raises(ValueError, match="per-segment control"):
+                build(*args, model=model)
+    with pytest.raises(ValueError, match="non-empty"):
+        build_segment_paint(iter([]))
 
 
 @pytest.mark.parametrize("model", ["H617A", "H6199"])

--- a/tools/ble/kaitai/govee_segment_page.ksy
+++ b/tools/ble/kaitai/govee_segment_page.ksy
@@ -1,0 +1,45 @@
+meta:
+  id: govee_segment_page
+  title: Shared Govee segment readback page
+  endian: le
+  imports:
+    - govee_shared
+doc: |
+  Brightness/RGB records with model-declared cardinality. Wire slots need not
+  all represent segments. Unused octets are retained, never inferred from black
+  or off records. Only models with evidenced zero padding enforce zeroes.
+params:
+  - id: segment_count
+    type: u1
+  - id: group_size
+    type: u1
+  - id: unused_must_be_zero
+    type: bool
+seq:
+  - id: group
+    type: u1
+    valid:
+      min: 1
+      max: (segment_count + group_size - 1) / group_size
+  - id: segments
+    type: segment_record
+    repeat: expr
+    repeat-expr: num_segments
+  - id: unused
+    doc: Opaque unused slot octets, including unexpected nonzero values where allowed.
+    type: u1
+    repeat: expr
+    repeat-expr: (4 - num_segments) * 4
+    valid:
+      expr: not unused_must_be_zero or _ == 0
+instances:
+  num_segments:
+    doc: Meaningful record count, independent of unused wire slots and record values.
+    value: 'group * group_size <= segment_count ? group_size : segment_count - (group - 1) * group_size'
+types:
+  segment_record:
+    seq:
+      - id: brightness
+        type: u1
+      - id: colour
+        type: govee_shared::rgb

--- a/tools/ble/kaitai/h6199_status_reply.ksy
+++ b/tools/ble/kaitai/h6199_status_reply.ksy
@@ -4,8 +4,10 @@ meta:
   endian: le
   imports:
     - govee_shared
+    - govee_segment_page
 doc: |
   H6199 20-byte status reply. The final byte is the XOR of bytes 0 through 18.
+  Segment groups carry 4+4+4+3 records; the final four bytes remain opaque.
 seq:
   - id: header
     contents: [0xaa]
@@ -26,7 +28,7 @@ seq:
         'status_domain::colour_mode': colour_mode_body
         'status_domain::display_setting': display_setting_body
         'status_domain::relative_brightness': relative_brightness_body
-        'status_domain::segments': segment_group_body
+        'status_domain::segments': govee_segment_page(15, 4, false)
   - id: checksum
     type: u1
 enums:
@@ -179,26 +181,6 @@ types:
     seq:
       - id: percent
         type: u1
-  segment_record:
-    seq:
-      - id: brightness_percent
-        type: u1
-      - id: colour
-        type: govee_shared::rgb
-  segment_group_body:
-    doc: Groups 1 through 3 carry four records; group 4 carries three records followed by four unparsed bytes.
-    seq:
-      - id: group
-        type: u1
-        valid:
-          min: 1
-          max: 4
-      - id: segments
-        type: segment_record
-        repeat: expr
-        repeat-expr: 'group == 4 ? 3 : 4'
-      - size: 4
-        if: group == 4
   version_body:
     seq:
       - id: text

--- a/tools/ble/kaitai/speculative/h66a0_status_reply.ksy
+++ b/tools/ble/kaitai/speculative/h66a0_status_reply.ksy
@@ -1,0 +1,33 @@
+meta:
+  id: h66a0_status_reply
+  title: H66A0 segment status hypothesis (fixture only)
+  endian: le
+  imports:
+    - /govee_segment_page
+doc: |
+  SPECULATIVE H66A0, issue #272 concern 3. The reported official-app frames
+  aa a5 01 64e54444 64ffae54 64ffae54 64cf2e2e 24 and
+  aa a5 04 64dc3b3b 64e54444 00000000 00000000 32 support a four-slot
+  brightness/RGB page hypothesis with reported 14-segment, 4+4+4+2 paging.
+  Unknowns: pages 2 and 3 have not been supplied, physical segment ordering
+  and readback behaviour remain unqualified, and unused final-page slots
+  have no established meaning or zero constraint. Preserve their raw octets.
+  No other status domains or models are inferred. This root is for generated
+  fixture tests only, not runtime support, discovery, or a whole-family alias.
+seq:
+  - id: header
+    contents: [0xaa]
+  - id: domain
+    type: u1
+    enum: status_domain
+  - id: body
+    size: 17
+    type:
+      switch-on: domain
+      cases:
+        'status_domain::segments': govee_segment_page(14, 4, false)
+  - id: checksum
+    type: u1
+enums:
+  status_domain:
+    0xa5: segments

--- a/tools/ble/kaitai/status_reply.ksy
+++ b/tools/ble/kaitai/status_reply.ksy
@@ -3,10 +3,11 @@ meta:
   title: Govee H617A "aa" status-reply envelope (decode-only)
   endian: le
   imports:
-    - govee_shared
+    - govee_segment_page
     - govee_common
 doc: |
   H617A 20-byte status reply. The final byte is the XOR of bytes 0 through 18.
+  Segment replies have five groups of three records and four validated-zero bytes.
 seq:
   - id: header
     contents: [0xaa]
@@ -23,7 +24,7 @@ seq:
         'aa_domain::colormode': colormode_body
         'aa_domain::fw_version': version_body
         'aa_domain::hw_version': hw_version_body
-        'aa_domain::segments': segments_body
+        'aa_domain::segments': govee_segment_page(15, 3, true)
         'aa_domain::multi_effect': multi_effect_body
   - id: checksum
     type: u1
@@ -120,26 +121,3 @@ types:
         type: u1
         valid: 0
         repeat: eos
-  segments_body:
-    doc: Five query-backed groups of three segment brightness and colour records.
-    seq:
-      - id: group
-        type: u1
-        valid:
-          min: 1
-          max: 5
-      - id: segments
-        type: segment
-        repeat: expr
-        repeat-expr: 3
-        if: group >= 1 and group <= 5
-      - id: padding
-        type: u1
-        valid: 0
-        repeat: eos
-  segment:
-    seq:
-      - id: brightness
-        type: u1
-      - id: colour
-        type: govee_shared::rgb


### PR DESCRIPTION
## Summary

- Declare reusable A3/Workshop effect grammar independently of exact-model capabilities and require supported Workshop application routes.
- Validate segment commands against effective device profiles before preview/state/write side effects; share segment-page KSY while preserving model-specific cardinality and unused-byte rules.
- Declare music capabilities explicitly so encoding registry growth cannot widen existing model support.

## Scope

Partially addresses #272. Existing supported-device behavior remains the release scope. H66A0 remains unsupported; no H6076 effects are enabled. Remaining exact-model basic-effect/canonical-template/scene dispatch and optional effective-profile omission are documented extension constraints, not claimed resolved by this PR. Keep #272 open.

## Validation

- Full make check: 1025 Python tests, 241 frontend unit tests, 17 browser tests; speculative fixture passes the separate all-schema gate.
- Exact candidate Check, Hassfest and HACS passed: https://github.com/teh-hippo/ha-govee-led-ble/actions/runs/34315909133
- Independent correctness, completeness and Ponytail reviews completed; findings and residual scope documented on #272.
- Immutable RC v7.4.2-rc.1.issue272 installed through HACS on owner HA 2026.9.1 and restarted successfully.
- Two H617A devices and one H6199 passed power/brightness readback and restoration. Static H617A additionally passed RGB, colour-temperature companion and first/last-segment colour/brightness checks. All devices restored off in original modes/brightness.
- No Govee system-log entries or current packet-diagnostic RX anomalies. Music, Workshop uploads and H6199 segment writes were not live-tested.

Owner approved stable release of this scoped improvement with unsupported gaps remaining unsupported.