### PR TITLE
fix: decouple command and status grammars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ Every exact SKU has its own profile, support quality, catalogue identity, and pr
 
 ### Reusing device protocol support
 
-- Declare `command_grammar` and `status_grammar` explicitly, even when they select the same grammar. Commands, outgoing status queries, command echoes, and optimistic command expectations use `command_grammar`; incoming status frames and their semantic interpretation use `status_grammar`. Missing or unknown grammar keys fail closed, without falling back to another direction or exact model.
+- Declare `command_grammar` and `status_grammar` explicitly, even when they select the same grammar. Basic commands, outgoing basic status queries, command echoes, and optimistic command expectations use `command_grammar`; incoming status frames and their semantic interpretation use `status_grammar`. Missing or unknown grammar keys fail closed, without falling back to another direction or exact model.
+- Any declared read domain requires `status_grammar`; power, brightness, colour mode, mode, firmware, hardware, and segment reads also require `command_grammar`. The selected complete status root must cover every declared read domain, proven by an exact-profile integration test. Do not add fallback or per-domain status routing, or a Python grammar-metadata registry.
 - Declare `effect_grammar` independently of basic command and status compatibility. It selects A3 and Workshop codecs, including their canonical semantics; it does not authorize effect application, catalogue reuse, activation, or readback policy. Workshop application also requires the exact-model capability contract and an implemented activation route.
 - Declare video modes and setting capabilities on the exact-model profile. `video_grammar` selects compatible mode, query, writer, readback, and command-ACK semantics independently of the basic grammars; it does not authorize a model or imply support for every companion setting. Grammar keys select codecs directly, not another model's profile.
 - Declare each model's `music_modes` explicitly. The shared slug-to-wire-ID registry records encoding knowledge, not product support.
@@ -35,6 +36,8 @@ Every exact SKU has its own profile, support quality, catalogue identity, and pr
 - Reuse `govee_segment_page` in status KSY with the evidenced segment count, page size, and unused-byte rule. Its fixed page body has four wire slots; only the declared meaningful records contribute to observed state. Keep profile counts consistent with the selected schema, and preserve uncertain unused bytes rather than treating zero-valued records as absent.
 
 Extension tests should demonstrate reuse through declarations without unrelated exact-model codec allowlist edits. Register a test-only exact-model profile and an independent status-root key rather than replacing an existing root or mocking profile lookup. Synthetic profiles and speculative fixtures establish these software boundaries, not physical device compatibility; the H66A0 fixture does not enable real H66A0 runtime support.
+
+Partial fixtures must declare only the minimal capabilities and read domains they exercise, rather than inherit a full device's contract.
 
 ### Outbound transmission
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Do not post the Bluetooth address, serial number, account details, or other uniq
 
 ## Project structure
 
-- `custom_components/ha_govee_led_ble/const.py` owns the exact-model `ModelProfile` registry.  Profiles declare product capabilities and runtime policy; `wire_model` may reuse another model's protocol only where the bytes are compatible.
+- `custom_components/ha_govee_led_ble/const.py` owns the exact-model `ModelProfile` registry.  Profiles declare product capabilities and runtime policy; `command_grammar` and `status_grammar` independently select compatible outbound and inbound protocols.
 - `tools/ble/kaitai/**/*.ksy` is the only BLE wire-structure source.  Generated modules under `generated_protocol/` are build outputs and are never edited manually.
 - `generated_protocol_adapter.py` connects generated structures to semantic builders and parsers.  Handwritten protocol code is limited to semantic transforms, checksums, and transport framing.
 - `coordinator*.py` owns connection lifecycle, queries, notifications, state, verification, and diagnostics.
@@ -27,13 +27,14 @@ Every exact SKU has its own profile, support quality, catalogue identity, and pr
 
 ### Reusing device protocol support
 
-- Declare `effect_grammar` independently of basic `wire_model` compatibility. It selects A3 and Workshop codecs, including their canonical semantics; it does not authorize effect application, catalogue reuse, activation, or readback policy. Workshop application also requires the exact-model capability contract and an implemented activation route.
-- Declare video modes and setting capabilities on the exact-model profile. `video_grammar` selects compatible mode, query, writer, and readback semantics; it does not authorize a model or imply support for every companion setting.
+- Declare `command_grammar` and `status_grammar` explicitly, even when they select the same grammar. Commands, outgoing status queries, command echoes, and optimistic command expectations use `command_grammar`; incoming status frames and their semantic interpretation use `status_grammar`. Missing or unknown grammar keys fail closed, without falling back to another direction or exact model.
+- Declare `effect_grammar` independently of basic command and status compatibility. It selects A3 and Workshop codecs, including their canonical semantics; it does not authorize effect application, catalogue reuse, activation, or readback policy. Workshop application also requires the exact-model capability contract and an implemented activation route.
+- Declare video modes and setting capabilities on the exact-model profile. `video_grammar` selects compatible mode, query, writer, readback, and command-ACK semantics independently of the basic grammars; it does not authorize a model or imply support for every companion setting. Grammar keys select codecs directly, not another model's profile.
 - Declare each model's `music_modes` explicitly. The shared slug-to-wire-ID registry records encoding knowledge, not product support.
 - Pass the effective device profile to semantic segment builders. Construct and validate the entire request before cancelling previews, acquiring user control, changing optimistic state, or writing to BLE. Whole-device masks remain separate from individually selectable segments.
 - Reuse `govee_segment_page` in status KSY with the evidenced segment count, page size, and unused-byte rule. Its fixed page body has four wire slots; only the declared meaningful records contribute to observed state. Keep profile counts consistent with the selected schema, and preserve uncertain unused bytes rather than treating zero-valued records as absent.
 
-Extension tests should demonstrate reuse through declarations without unrelated exact-model codec allowlist edits. Synthetic profiles and speculative fixtures establish these software boundaries, not physical device compatibility.
+Extension tests should demonstrate reuse through declarations without unrelated exact-model codec allowlist edits. Register a test-only exact-model profile and an independent status-root key rather than replacing an existing root or mocking profile lookup. Synthetic profiles and speculative fixtures establish these software boundaries, not physical device compatibility; the H66A0 fixture does not enable real H66A0 runtime support.
 
 ### Outbound transmission
 

--- a/custom_components/ha_govee_led_ble/const.py
+++ b/custom_components/ha_govee_led_ble/const.py
@@ -121,6 +121,22 @@ class ModelProfile:
     def __post_init__(self) -> None:
         if not self.setup_required_read_domains <= self.read_domains:
             raise ValueError("setup-required read domains must also be readable")
+        if self.read_domains and self.status_grammar is None:
+            raise ValueError("read domains require a status grammar")
+        if (
+            self.read_domains
+            & {
+                ReadDomain.POWER,
+                ReadDomain.BRIGHTNESS,
+                ReadDomain.COLOUR_MODE,
+                ReadDomain.MODE,
+                ReadDomain.FIRMWARE,
+                ReadDomain.HARDWARE,
+                ReadDomain.SEGMENTS,
+            }
+            and self.command_grammar is None
+        ):
+            raise ValueError("basic read domains require a command grammar")
         if self.video_modes and self.video_grammar is None:
             raise ValueError("video modes require a grammar")
         if self.supports_video_mode and not self.video_modes:

--- a/custom_components/ha_govee_led_ble/const.py
+++ b/custom_components/ha_govee_led_ble/const.py
@@ -76,7 +76,8 @@ _IDENTITY_READ_DOMAINS = frozenset(
 class ModelProfile:
     name: str
     support_quality: SupportQuality = SupportQuality.EXPERIMENTAL
-    wire_model: str | None = None
+    command_grammar: str | None = None
+    status_grammar: str | None = None
     outbound_transform: Callable[[bytes], bytes] | None = None
     # Effect semantics require evidence independent of basic command compatibility.
     effect_grammar: str | None = None
@@ -184,7 +185,8 @@ _H6199_MUSIC_MODES = ("energetic", "rhythm", "spectrum", "rolling")
 _H617A_PROFILE = ModelProfile(
     "H617A LED Strip",
     support_quality=SupportQuality.SUPPORTED,
-    wire_model="H617A",
+    command_grammar="H617A",
+    status_grammar="H617A",
     effect_grammar="H617A",
     read_domains=frozenset(
         {
@@ -267,7 +269,8 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "H6076": ModelProfile(
         "H6076 Lyra Floor Lamp",
         support_quality=SupportQuality.PARTIAL,
-        wire_model="H617A",
+        command_grammar="H617A",
+        status_grammar="H617A",
         read_domains=frozenset(
             {
                 ReadDomain.POWER,
@@ -287,7 +290,8 @@ MODEL_PROFILES: dict[str, ModelProfile] = {
     "H6199": ModelProfile(
         "H6199 DreamView T1",
         support_quality=SupportQuality.SUPPORTED,
-        wire_model="H6199",
+        command_grammar="H6199",
+        status_grammar="H6199",
         effect_grammar="H6199",
         video_grammar="H6199",
         read_domains=frozenset(
@@ -363,11 +367,6 @@ def protocol_model(model: str) -> str | None:
     """Resolve legacy runtime policy identity, not effect-grammar compatibility."""
     resolved = resolve_model(model)
     return "H617A" if resolved in {"H617A", "H617E"} else resolved
-
-
-def wire_model(model: str) -> str | None:
-    resolved = resolve_model(model)
-    return MODEL_PROFILES[resolved].wire_model if resolved is not None else None
 
 
 def get_profile(model: str) -> ModelProfile:

--- a/custom_components/ha_govee_led_ble/coordinator.py
+++ b/custom_components/ha_govee_led_ble/coordinator.py
@@ -930,7 +930,9 @@ class GoveeBLECoordinator(_ActiveModeMixin):
                     observed = ("is_on",)
             elif domain is StatusDomain.BRIGHTNESS:
                 brightness_value = (
-                    int(generated.body.percent) if self.model == "H6199" else int(generated.body.brightness_pct)
+                    int(generated.body.percent)
+                    if self.profile.status_grammar == "H6199"
+                    else int(generated.body.brightness_pct)
                 )
                 if self._accept_expected("brightness_pct", brightness_value):
                     self.brightness_pct = brightness_value

--- a/custom_components/ha_govee_led_ble/coordinator_expectations.py
+++ b/custom_components/ha_govee_led_ble/coordinator_expectations.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from .const import MUSIC_MODE_SLUGS, get_profile, wire_model
+from .const import MUSIC_MODE_SLUGS, get_profile
 from .coordinator_status import ParsedMode
 from .generated_protocol_adapter import parse_command
 from .light_commands import parse_static_write
@@ -38,7 +38,7 @@ def expectations_from_packet(
         static_echoes_color=static_echoes_color,
     ):
         expectations["color_mode"] = color_mode
-    if wire_model(model) == "H6199":
+    if get_profile(model).command_grammar == "H6199":
         if operation != "mode":
             return expectations
         mode = getattr(generated.body.sub_mode, "name", None)
@@ -109,7 +109,7 @@ def _expected_color_mode(
     *,
     static_echoes_color: bool,
 ) -> tuple[ParsedMode, int | None] | None:
-    if wire_model(model) == "H6199":
+    if get_profile(model).command_grammar == "H6199":
         if generated.opcode.name != "mode":
             return None
         mode = getattr(generated.body.sub_mode, "name", None)

--- a/custom_components/ha_govee_led_ble/coordinator_status.py
+++ b/custom_components/ha_govee_led_ble/coordinator_status.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, cast
 
-from .const import MUSIC_MODE_SLUGS, ReadDomain, get_profile, wire_model
+from .const import MUSIC_MODE_SLUGS, ReadDomain, get_profile
 from .generated_protocol_adapter import ProtocolParseResult, parse_status_result
 from .scenes import MODEL_SCENES
 
@@ -99,7 +99,7 @@ class ParsedColorModeResponse:
 def parse_color_mode(generated: Any, model: str) -> ParsedColorModeResponse:
     body = generated.body
     mode_name = getattr(body.mode, "name", None)
-    if wire_model(model) == "H6199":
+    if get_profile(model).status_grammar == "H6199":
         if mode_name == "video":
             profile = get_profile(model)
             if profile.video_grammar != "H6199":

--- a/custom_components/ha_govee_led_ble/effect_compiler.py
+++ b/custom_components/ha_govee_led_ble/effect_compiler.py
@@ -311,9 +311,9 @@ def workshop_apply_code(model: str) -> int:
     if studio_apply_capability_state(model, CapabilityWorkflow.WORKSHOP) is not CapabilityState.SUPPORTED:
         raise ValueError(f"{model} Workshop application is not supported")
     profile = get_profile(model)
-    if profile.effect_grammar == "H617A" and profile.wire_model == "H617A":
+    if profile.effect_grammar == "H617A" and profile.command_grammar == "H617A":
         return H617A_WORKSHOP_APPLY_CODE
-    if profile.effect_grammar == "H6199" and profile.wire_model == "H6199":
+    if profile.effect_grammar == "H6199" and profile.command_grammar == "H6199":
         return H6199_WORKSHOP_APPLY_CODE
     raise ValueError(f"{model} has no supported Workshop grammar and activation route")
 

--- a/custom_components/ha_govee_led_ble/generated_protocol_adapter.py
+++ b/custom_components/ha_govee_led_ble/generated_protocol_adapter.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 
 from kaitaistruct import ConsistencyError, KaitaiStream, KaitaiStructError, ReadWriteKaitaiStruct
 
-from .const import get_profile, wire_model
+from .const import get_profile
 from .transport import A3_CHUNK_SIZE, xor_checksum
 
 CommandWrite = cast(
@@ -186,17 +186,16 @@ _COMMAND_ACK_ROOTS = {
 
 def _parse_xor_frame(
     frame: bytes,
-    model: str,
+    grammar: str | None,
     roots: dict[str, tuple[str, Any]],
 ) -> ProtocolParseResult:
     if len(frame) != 20:
         return ProtocolParseResult(None, None, ProtocolParseRejection.INVALID_LENGTH)
     if xor_checksum(frame[:-1]) != frame[-1]:
         return ProtocolParseResult(None, None, ProtocolParseRejection.INVALID_CHECKSUM)
-    resolved = wire_model(model)
-    if resolved is None:
+    if grammar is None:
         return ProtocolParseResult(None, None, ProtocolParseRejection.UNSUPPORTED_MODEL)
-    root = roots.get(resolved)
+    root = roots.get(grammar)
     if root is None:
         return ProtocolParseResult(None, None, ProtocolParseRejection.UNSUPPORTED_MODEL)
     parser, root_type = root
@@ -209,7 +208,7 @@ def _parse_xor_frame(
 
 
 def parse_status_result(frame: bytes, model: str = "H617A") -> ProtocolParseResult:
-    return _parse_xor_frame(frame, model, _STATUS_ROOTS)
+    return _parse_xor_frame(frame, get_profile(model).status_grammar, _STATUS_ROOTS)
 
 
 def parse_status(frame: bytes, model: str = "H617A") -> Any | None:
@@ -217,7 +216,7 @@ def parse_status(frame: bytes, model: str = "H617A") -> Any | None:
 
 
 def parse_command_result(frame: bytes, model: str = "H617A") -> ProtocolParseResult:
-    return _parse_xor_frame(frame, model, _COMMAND_ROOTS)
+    return _parse_xor_frame(frame, get_profile(model).command_grammar, _COMMAND_ROOTS)
 
 
 def parse_command_ack_result(frame: bytes, model: str) -> ProtocolParseResult:
@@ -268,7 +267,7 @@ def parse_a3_effect_envelope(envelope: bytes, model: str) -> Any:
 
 
 def _command_types(model: str) -> tuple[Any, Any, Any]:
-    resolved = wire_model(model)
+    resolved = get_profile(model).command_grammar
     if resolved == "H6199":
         return (
             H6199CommandWrite,
@@ -290,15 +289,14 @@ _child = new_child
 
 def _build_status_query(
     domain: str,
-    model: str = "H617A",
+    grammar: str | None,
     *,
     display_setting: str | None = None,
     segment_group: int | None = None,
 ) -> bytes:
-    resolved = wire_model(model)
-    if resolved is None:
-        raise ValueError(f"{model} has no generated status-query grammar")
-    root_type = H6199StatusQuery if resolved == "H6199" else StatusQuery
+    if grammar not in {"H617A", "H6199"}:
+        raise ValueError(f"{grammar} has no generated status-query grammar")
+    root_type = H6199StatusQuery if grammar == "H6199" else StatusQuery
     root = root_type()
     root.header = b"\xaa"
     root.domain = getattr(root_type.QueryDomain, domain)
@@ -326,23 +324,23 @@ def _build_status_query(
 
 
 def build_power_query(model: str = "H617A") -> bytes:
-    return _build_status_query("power", model)
+    return _build_status_query("power", get_profile(model).command_grammar)
 
 
 def build_brightness_query(model: str = "H617A") -> bytes:
-    return _build_status_query("brightness", model)
+    return _build_status_query("brightness", get_profile(model).command_grammar)
 
 
 def build_colour_mode_query(model: str = "H617A") -> bytes:
-    return _build_status_query("colour_mode", model)
+    return _build_status_query("colour_mode", get_profile(model).command_grammar)
 
 
 def build_firmware_query(model: str = "H617A") -> bytes:
-    return _build_status_query("firmware", model)
+    return _build_status_query("firmware", get_profile(model).command_grammar)
 
 
 def build_hardware_query(model: str = "H617A") -> bytes:
-    return _build_status_query("hardware", model)
+    return _build_status_query("hardware", get_profile(model).command_grammar)
 
 
 def _video_grammar(model: str) -> str:
@@ -386,13 +384,13 @@ def build_h6199_subordinate_query(domain: int) -> bytes:
 
 
 def build_segment_query(group: int, model: str = "H617A") -> bytes:
-    resolved = wire_model(model)
-    if resolved is None:
+    resolved = get_profile(model).command_grammar
+    if resolved not in {"H617A", "H6199"}:
         raise ValueError(f"{model} has no generated segment-query grammar")
     maximum = 4 if resolved == "H6199" else 5
     if not 1 <= group <= maximum:
         raise ValueError(f"segment query group must be from 1 to {maximum}")
-    return _build_status_query("segments", model, segment_group=group)
+    return _build_status_query("segments", resolved, segment_group=group)
 
 
 def _rgb(parent: Any, red: int, green: int, blue: int) -> Any:
@@ -698,7 +696,7 @@ def build_segment_colour(
     blue: int,
     model: str = "H617A",
 ) -> bytes:
-    resolved = wire_model(model)
+    resolved = get_profile(model).command_grammar
     if resolved == "H6199":
         root = H6199CommandWrite()
         root.header = b"\x33"
@@ -734,7 +732,7 @@ def build_colour_temperature(
     model: str = "H617A",
 ) -> bytes:
     value = max(2000, min(9000, kelvin))
-    resolved = wire_model(model)
+    resolved = get_profile(model).command_grammar
     if resolved == "H6199":
         root = H6199CommandWrite()
         root.header = b"\x33"
@@ -769,7 +767,7 @@ def build_segment_brightness(
     model: str = "H617A",
 ) -> bytes:
     value = max(0, min(100, percent))
-    resolved = wire_model(model)
+    resolved = get_profile(model).command_grammar
     if resolved == "H6199":
         root = H6199CommandWrite()
         root.header = b"\x33"
@@ -972,7 +970,7 @@ def build_music_mode(
     calm: bool,
     model: str = "H617A",
 ) -> bytes:
-    resolved = wire_model(model)
+    resolved = get_profile(model).command_grammar
     if resolved == "H6199":
         root = H6199CommandWrite()
         root.header = b"\x33"

--- a/custom_components/ha_govee_led_ble/light_commands.py
+++ b/custom_components/ha_govee_led_ble/light_commands.py
@@ -129,7 +129,7 @@ def parse_static_write(packet: bytes, model: str = "H617A") -> ParsedStaticWrite
     if generated is None:
         return None
     whole_device_mask = get_profile(model).whole_device_mask
-    if model == "H6199":
+    if get_profile(model).command_grammar == "H6199":
         if generated.opcode.name != "mode" or getattr(generated.body.sub_mode, "name", None) != "static_colour":
             return None
         detail = generated.body.detail

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -108,6 +108,44 @@ def test_setup_required_domains_must_be_readable():
         ModelProfile("x", setup_required_read_domains=frozenset({ReadDomain.POWER}))
 
 
+@pytest.mark.parametrize("domain", list(ReadDomain))
+def test_read_domains_require_status_grammar(domain):
+    with pytest.raises(ValueError, match="read domains require a status grammar"):
+        ModelProfile("x", command_grammar="H6199", status_grammar=None, read_domains=frozenset({domain}))
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        ReadDomain.POWER,
+        ReadDomain.BRIGHTNESS,
+        ReadDomain.COLOUR_MODE,
+        ReadDomain.MODE,
+        ReadDomain.FIRMWARE,
+        ReadDomain.HARDWARE,
+        ReadDomain.SEGMENTS,
+    ],
+)
+def test_basic_read_domains_require_command_grammar(domain):
+    with pytest.raises(ValueError, match="basic read domains require a command grammar"):
+        ModelProfile("x", command_grammar=None, status_grammar="H6199", read_domains=frozenset({domain}))
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        ReadDomain.SUBORDINATE_20,
+        ReadDomain.SUBORDINATE_21,
+        ReadDomain.DISPLAY_SETTING,
+        ReadDomain.RELATIVE_BRIGHTNESS,
+        ReadDomain.OTHER,
+    ],
+)
+def test_non_basic_read_domains_do_not_require_command_grammar(domain):
+    profile = ModelProfile("x", command_grammar=None, status_grammar="H6199", read_domains=frozenset({domain}))
+    assert profile.can_read(domain)
+
+
 def test_unknown_models_fail_closed():
     assert get_profile("nope") is UNSUPPORTED_PROFILE
     assert not UNSUPPORTED_PROFILE.supports_segments

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -23,7 +23,6 @@ from custom_components.ha_govee_led_ble.const import (
     prefix_effect_names_from_options,
     protocol_model,
     resolve_model,
-    wire_model,
 )
 from custom_components.ha_govee_led_ble.coordinator import GoveeBLECoordinator
 from custom_components.ha_govee_led_ble.effect_compiler import CompatibilityState, compatibility, compile_music_profile
@@ -46,6 +45,16 @@ def test_segment_count_and_supports_segments():
 def test_supports_segments_defaults_false():
     assert ModelProfile("x").segment_count == 0
     assert not ModelProfile("x").supports_segments
+    assert ModelProfile("x").command_grammar is None
+    assert ModelProfile("x").status_grammar is None
+
+
+@pytest.mark.parametrize(
+    ("model", "grammar"), [("H617A", "H617A"), ("H617E", "H617A"), ("H6076", "H617A"), ("H6199", "H6199")]
+)
+def test_existing_profiles_preserve_both_directional_grammars(model, grammar):
+    assert get_profile(model).command_grammar == grammar
+    assert get_profile(model).status_grammar == grammar
 
 
 def test_h617a_and_h617e_share_wire_behaviour_but_keep_exact_product_profiles():
@@ -66,7 +75,7 @@ def test_h617a_and_h617e_share_wire_behaviour_but_keep_exact_product_profiles():
     assert h617e.connection_idle_timeout == 3.0
     assert resolve_model("H617E") == "H617E"
     assert protocol_model("H617E") == "H617A"
-    assert wire_model("H617E") == "H617A"
+    assert h617e.command_grammar == h617e.status_grammar == "H617A"
     assert h617e.effect_grammar == h617a.effect_grammar == "H617A"
 
 
@@ -89,7 +98,7 @@ def test_h6076_profile_is_basic_and_fail_closed():
     assert not profile.supports_music_mode
     assert not profile.supports_segments
     assert profile.whole_device_mask == 0x007F
-    assert wire_model("H6076") == "H617A"
+    assert profile.command_grammar == profile.status_grammar == "H617A"
     assert protocol_model("H6076") == "H6076"
     assert profile.effect_grammar is None
 
@@ -105,7 +114,8 @@ def test_unknown_models_fail_closed():
     assert not UNSUPPORTED_PROFILE.supports_music_mode
     assert resolve_model("H617A-extra") is None
     assert resolve_model("H9999") is None
-    assert wire_model("H9999") is None
+    assert get_profile("H9999").command_grammar is None
+    assert get_profile("H9999").status_grammar is None
     assert UNSUPPORTED_PROFILE.effect_grammar is None
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1331,6 +1331,8 @@ def test_video_grammar_owns_writers_and_ack_independently_of_basic_grammars(
             name="Synthetic video device",
             command_grammar="H617A",
             status_grammar=None,
+            read_domains=frozenset(),
+            setup_required_read_domains=frozenset(),
         ),
     )
 
@@ -1339,7 +1341,15 @@ def test_video_grammar_owns_writers_and_ack_independently_of_basic_grammars(
     expected_queries = [build("H6199") for build in queries]
     # Video grammar keys must not be resolved through the H6199 model profile.
     monkeypatch.setitem(
-        MODEL_PROFILES, "H6199", replace(MODEL_PROFILES["H6199"], command_grammar=None, status_grammar="unknown")
+        MODEL_PROFILES,
+        "H6199",
+        replace(
+            MODEL_PROFILES["H6199"],
+            command_grammar=None,
+            status_grammar="unknown",
+            read_domains=frozenset(),
+            setup_required_read_domains=frozenset(),
+        ),
     )
     assert [build(model) for build in queries] == expected_queries
     ack = parse_command_ack_result(bytes.fromhex("33a900000000000000000000000000000000009a"), model)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -51,6 +51,7 @@ from custom_components.ha_govee_led_ble.generated_protocol_adapter import (
     build_white_balance,
     build_white_balance_query,
     parse_command,
+    parse_command_ack_result,
     parse_status,
 )
 from custom_components.ha_govee_led_ble.h6199_calibration import WHITE_BALANCE_RESET
@@ -1318,18 +1319,96 @@ async def test_send_state_queries_include_h6199_display_state(h6199):
     ]
 
 
-def test_video_grammar_owns_writers_independently_of_basic_wire_model(
+def test_video_grammar_owns_writers_and_ack_independently_of_basic_grammars(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     model = "H7000"
     monkeypatch.setitem(
         MODEL_PROFILES,
         model,
-        replace(MODEL_PROFILES["H6199"], name="Synthetic video device", wire_model="H617A"),
+        replace(
+            MODEL_PROFILES["H6199"],
+            name="Synthetic video device",
+            command_grammar="H617A",
+            status_grammar=None,
+        ),
     )
 
     assert build_video_mode("game", False, 42, True, 55, model) == build_h6199_video(False, True, 42, True, 55)
-    assert build_white_balance_query(model) == build_white_balance_query("H6199")
+    queries = (build_white_balance_query, build_blank_screen_query, build_relative_brightness_query)
+    expected_queries = [build("H6199") for build in queries]
+    # Video grammar keys must not be resolved through the H6199 model profile.
+    monkeypatch.setitem(
+        MODEL_PROFILES, "H6199", replace(MODEL_PROFILES["H6199"], command_grammar=None, status_grammar="unknown")
+    )
+    assert [build(model) for build in queries] == expected_queries
+    ack = parse_command_ack_result(bytes.fromhex("33a900000000000000000000000000000000009a"), model)
+    assert ack.parser == "h6199_command_ack" and ack.rejection is None
+    assert ack.parsed is not None and ack.parsed.opcode.name == "display_setting"
+
+
+@pytest.mark.parametrize(("command_grammar", "status_grammar"), [("H617A", "H6199"), ("H6199", "H617A")])
+def test_mixed_grammars_route_command_expectations_and_status_semantics(
+    hass, monkeypatch, command_grammar, status_grammar
+):
+    model = "H7000"
+    monkeypatch.setitem(
+        MODEL_PROFILES,
+        model,
+        replace(
+            MODEL_PROFILES[status_grammar],
+            name="Synthetic mixed-grammar device",
+            command_grammar=command_grammar,
+            status_grammar=status_grammar,
+        ),
+    )
+    coordinator = GoveeBLECoordinator(hass, "AA:BB:CC:DD:EE:FF", model, configuration_url=_CONFIGURATION_URL)
+    brightness = build_brightness(37, model)
+    assert brightness == build_brightness(37, command_grammar)
+    assert expectations_from_packet(brightness, model) == {"brightness_pct": 37}
+    for build, args, field, expected in (
+        (build_color_rgb, (10, 20, 30), "rgb_color", (10, 20, 30)),
+        (build_color_temp, (4000,), "color_temp_kelvin", 4000),
+        (build_white_brightness, (80,), "white_brightness", 80),
+    ):
+        packet = build(*args, model=model)
+        assert packet == build(*args, model=command_grammar)
+        expectations = expectations_from_packet(packet, model, static_echoes_color=True)
+        assert expectations[field] == expected
+        assert expectations["color_mode"] == (ParsedMode.COLOUR, 2 if field == "white_brightness" else 1)
+
+    music = build_music_mode(MUSIC_MODE_SLUGS["rhythm"], 50, (10, 20, 30), True, model)
+    assert music == build_music_mode(MUSIC_MODE_SLUGS["rhythm"], 50, (10, 20, 30), True, command_grammar)
+    assert expectations_from_packet(music, model) == {
+        "color_mode": (ParsedMode.MUSIC, None),
+        "music_mode": "rhythm",
+        "music_sensitivity": 50,
+        "music_calm": True,
+        "music_color": (10, 20, 30),
+    }
+
+    # Group 5 distinguishes outbound query grammars even with the opposite reply layout.
+    assert build_brightness_query(model) == build_brightness_query(command_grammar)
+    if command_grammar == "H617A":
+        assert build_segment_query(5, model) == build_segment_query(5, "H617A")
+    else:
+        assert build_segment_query(4, model) == build_segment_query(4, "H6199")
+        with pytest.raises(ValueError, match="1 to 4"):
+            build_segment_query(5, model)
+
+    coordinator._notify_callback(None, bytearray(_packet(0xAA, 0x04, [37])))
+    assert coordinator.brightness_pct == 37
+    assert coordinator._field_revisions["brightness_pct"] == 1
+    music_reply = {
+        "H617A": "aa051303580100000000000000000000000000e6",
+        "H6199": "aa0513044d0001010203000000000000000000f4",
+    }[status_grammar]
+    coordinator._notify_callback(None, bytearray.fromhex(music_reply))
+    assert coordinator.color_mode is ParsedMode.MUSIC
+    assert coordinator.music_mode == ("rhythm" if status_grammar == "H617A" else "spectrum")
+    assert coordinator.music_sensitivity == (88 if status_grammar == "H617A" else 77)
+    assert coordinator.music_color == (None if status_grammar == "H617A" else (1, 2, 3))
+    assert coordinator._field_revisions["color_mode"] == 1
 
 
 async def test_send_state_queries_include_h617a_core_state(coord):

--- a/tests/test_diy_protocol.py
+++ b/tests/test_diy_protocol.py
@@ -311,7 +311,7 @@ def test_profile_effect_grammar_enables_codecs_without_authorizing_application(m
     )
     with pytest.raises(ValueError, match="activation route"):
         compile_effect(item, model)
-    monkeypatch.setitem(MODEL_PROFILES, model, replace(MODEL_PROFILES[model], wire_model=grammar))
+    monkeypatch.setitem(MODEL_PROFILES, model, replace(MODEL_PROFILES[model], command_grammar=grammar))
     compiled = compile_effect(item, model)
     reference = compile_effect(LibraryItem.new("Reference", workshop), grammar)
     assert compiled.model == model
@@ -320,9 +320,11 @@ def test_profile_effect_grammar_enables_codecs_without_authorizing_application(m
 
 
 @pytest.mark.parametrize("model", ["H6076", "H9999"])
-def test_basic_wire_alias_does_not_supply_effect_grammar(monkeypatch, model) -> None:
+def test_basic_grammars_do_not_supply_effect_grammar(monkeypatch, model) -> None:
     if model == "H9999":
-        monkeypatch.setitem(MODEL_PROFILES, model, ModelProfile("Synthetic", wire_model="H617A"))
+        monkeypatch.setitem(
+            MODEL_PROFILES, model, ModelProfile("Synthetic", command_grammar="H617A", status_grammar="H617A")
+        )
     workshop = WORKSHOP_PROTOCOL_FIXTURES[0].content("H617A")
     envelope = reassemble_a3(fragment_a3(2, workshop.raw_param))
     parsed = parse_a3_effect_envelope(envelope, "H617A")

--- a/tests/test_kaitai_protocol.py
+++ b/tests/test_kaitai_protocol.py
@@ -8,16 +8,23 @@ import sys
 from dataclasses import replace
 from importlib import import_module
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 from kaitaistruct import KaitaiStream, KaitaiStructError
 
 from custom_components.ha_govee_led_ble import generated_protocol_adapter
-from custom_components.ha_govee_led_ble.const import MODEL_PROFILES, UNSUPPORTED_PROFILE, get_profile
+from custom_components.ha_govee_led_ble.const import (
+    MODEL_PROFILES,
+    UNSUPPORTED_PROFILE,
+    ModelProfile,
+    ReadDomain,
+    get_profile,
+)
 from custom_components.ha_govee_led_ble.coordinator import GoveeBLECoordinator
 from custom_components.ha_govee_led_ble.coordinator_expectations import expectations_from_packet
 from custom_components.ha_govee_led_ble.generated_protocol_adapter import ProtocolParseRejection
-from custom_components.ha_govee_led_ble.transport import xor_checksum
+from custom_components.ha_govee_led_ble.transport import WRITE_UUID, xor_checksum
 
 _GENERATED_DIR = os.environ.get("KAITAI_GENERATED_DIR")
 if _GENERATED_DIR:
@@ -152,7 +159,16 @@ def test_h6199_command_acknowledgement_rejects_unobserved_opcodes() -> None:
 @pytest.mark.parametrize("grammar", [None, "unknown"])
 @pytest.mark.parametrize("direction", ["command", "status"])
 def test_missing_or_unknown_grammar_fails_closed_only_in_its_direction(monkeypatch, grammar, direction) -> None:
-    monkeypatch.setitem(MODEL_PROFILES, "H617A", replace(MODEL_PROFILES["H617A"], **{f"{direction}_grammar": grammar}))
+    monkeypatch.setitem(
+        MODEL_PROFILES,
+        "H617A",
+        replace(
+            MODEL_PROFILES["H617A"],
+            read_domains=frozenset(),
+            setup_required_read_domains=frozenset(),
+            **{f"{direction}_grammar": grammar},
+        ),
+    )
     command = generated_protocol_adapter.parse_command_result(COMMAND_STATIC)
     status = generated_protocol_adapter.parse_status_result(STATUS_SEGMENTS)
     rejected, accepted = (command, status) if direction == "command" else (status, command)
@@ -218,9 +234,20 @@ def test_h6199_segment_pages_preserve_opaque_tail(group: int) -> None:
     assert output.to_byte_array() == frame
 
 
-@pytest.mark.skipif(not _GENERATED_DIR, reason="H66A0 is an all-schema fixture, not a runtime root")
-def test_h66a0_four_slot_pages_reach_semantic_observation(hass, monkeypatch) -> None:
-    root = _generated("h66a0_status_reply", "H66a0StatusReply")
+@pytest.mark.skipif(not _GENERATED_DIR, reason="Synthetic layouts are all-schema fixtures, not runtime roots")
+@pytest.mark.parametrize(
+    ("schema", "class_name", "read_domains"),
+    [
+        ("h66a0_status_reply", "H66a0StatusReply", frozenset({ReadDomain.SEGMENTS})),
+        (
+            "synthetic_mixed_status_reply",
+            "SyntheticMixedStatusReply",
+            frozenset({ReadDomain.POWER, ReadDomain.SEGMENTS}),
+        ),
+    ],
+)
+async def test_four_slot_profile_observes_every_declared_domain(hass, monkeypatch, schema, class_name, read_domains):
+    root = _generated(schema, class_name)
     first = bytes.fromhex("aaa50164e5444464ffae5464ffae5464cf2e2e24")
     final = bytes.fromhex("aaa50464dc3b3b64e54444000000000000000032")
     # Pages 2/3 are synthetic, including a meaningful black/off segment.
@@ -252,28 +279,29 @@ def test_h66a0_four_slot_pages_reach_semantic_observation(hass, monkeypatch) -> 
     # A synthetic exact model reuses outbound H617A bytes and independently selects
     # the speculative layout. Neither the real H66A0 nor H617A changes support.
     model = "H7000"
-    status_grammar = "test-h66a0-pages"
-    profile = replace(
-        MODEL_PROFILES["H617A"],
-        name="Synthetic 14-segment device",
+    status_grammar = "test-four-slot-pages"
+    profile = ModelProfile(
+        "Synthetic 14-segment device",
         command_grammar="H617A",
         status_grammar=status_grammar,
+        read_domains=read_domains,
         segment_count=14,
         segment_group_size=4,
+        supports_segment_writes=True,
+        whole_device_mask=0x3FFF,
     )
     monkeypatch.setitem(MODEL_PROFILES, model, profile)
-    monkeypatch.setitem(generated_protocol_adapter._STATUS_ROOTS, status_grammar, ("h66a0_status_reply", root))
+    monkeypatch.setitem(generated_protocol_adapter._STATUS_ROOTS, status_grammar, (schema, root))
     coordinator = GoveeBLECoordinator(
         hass, "AA:BB:CC:DD:EE:FF", model, configuration_url="homeassistant://ha-govee-led-ble/editor/test"
     )
     assert coordinator.profile is profile
-    command = generated_protocol_adapter.build_colour_temperature(3600, (255, 203, 141), 0x7FFF, model)
-    assert command == COMMAND_STATIC
+    command = generated_protocol_adapter.build_power(True, model)
+    assert command == bytes.fromhex("3301010000000000000000000000000000000033")
     parsed_command = generated_protocol_adapter.parse_command_result(command, model)
     assert parsed_command.parser == "command_write" and parsed_command.parsed is not None
-    assert parsed_command.parsed.body.sub_body.static_body.kelvin == 3600
-    assert generated_protocol_adapter.build_segment_query(5, model) == H617A_SEGMENT_QUERY
-    assert generated_protocol_adapter.parse_status_result(first, model).parser == "h66a0_status_reply"
+    assert parsed_command.parsed.body.is_on == 1
+    assert generated_protocol_adapter.parse_status_result(first, model).parser == schema
     assert generated_protocol_adapter.parse_status_result(STATUS_SEGMENTS, "H617A").parsed is not None
     assert (
         generated_protocol_adapter.parse_status_result(first, "H617A").rejection
@@ -294,33 +322,6 @@ def test_h66a0_four_slot_pages_reach_semantic_observation(hass, monkeypatch) -> 
         assert coordinator.segment_state_source == "initial"
         assert coordinator._field_revisions.get("segment_colors", 0) == 0
 
-    # Reject malformed frames without corrupting the pending four-page observation.
-    before = coordinator._state_snapshot()
-    revisions = dict(coordinator._field_revisions)
-    domains = dict(coordinator._domain_revisions)
-    assert coordinator._segment_query_colors is not None
-    assert coordinator._segment_query_brightness is not None
-    colours = list(coordinator._segment_query_colors)
-    brightness = list(coordinator._segment_query_brightness)
-    invalid_group = first[:2] + b"\x05" + first[3:-1]
-    invalid_group += bytes((xor_checksum(invalid_group),))
-    for frame, rejection in (
-        (first[:-1], ProtocolParseRejection.INVALID_LENGTH),
-        (first[:-1] + bytes((first[-1] ^ 1,)), ProtocolParseRejection.INVALID_CHECKSUM),
-        (invalid_group, ProtocolParseRejection.SCHEMA_REJECTED),
-    ):
-        assert generated_protocol_adapter.parse_status_result(frame, model).rejection is rejection
-        coordinator._notify_callback(None, bytearray(frame))
-        assert coordinator._state_snapshot() == before
-        assert coordinator._field_revisions == revisions
-        assert coordinator._domain_revisions == domains
-        assert coordinator._segment_query_colors == colours
-        assert coordinator._segment_query_brightness == brightness
-        assert coordinator._segment_groups_observed == {1, 3, 4}
-        assert coordinator.segment_colors == [(255, 255, 255)] * 14
-        assert coordinator.segment_brightness == [100] * 14
-        assert coordinator.segment_state_source == "initial"
-        assert coordinator.segment_state_observed_at is None
     coordinator._notify_callback(None, bytearray(second))
     assert coordinator.segment_state_source == "observed"
     assert coordinator.segment_state_observed_at is not None
@@ -347,6 +348,36 @@ def test_h66a0_four_slot_pages_reach_semantic_observation(hass, monkeypatch) -> 
     assert coordinator._field_revisions["segment_colors"] == 2
     assert len(coordinator.segment_colors) == len(coordinator.segment_brightness) == 14
     assert coordinator.segment_colors[-2:] == [(220, 59, 59), (229, 68, 68)]
+
+    # Exercise real command/query/notification paths, mocking only the BLE connection.
+    power_reply = bytes.fromhex("aa010100000000000000000000000000000000aa")
+    replies = {}
+    if profile.can_read(ReadDomain.POWER):
+        replies[generated_protocol_adapter.build_power_query("H617A")] = power_reply
+    replies.update(
+        (generated_protocol_adapter.build_segment_query(group, "H617A"), frame)
+        for group, frame in enumerate((first, second, third, final), 1)
+    )
+
+    async def write(_uuid, packet, **_kwargs):
+        if packet != command:
+            coordinator._notify_callback(None, bytearray(replies[packet]))
+
+    client = MagicMock(is_connected=True, write_gatt_char=AsyncMock(side_effect=write))
+    coordinator._client = client
+    monkeypatch.setattr(coordinator, "_ensure_connected", AsyncMock(return_value=client))
+    monkeypatch.setattr(coordinator, "_reset_disconnect_timer", lambda: None)
+    await coordinator.send_command(command)
+    client.write_gatt_char.assert_awaited_once_with(WRITE_UUID, command, response=False)
+    client.write_gatt_char.reset_mock()
+    if profile.can_read(ReadDomain.POWER):
+        assert generated_protocol_adapter.parse_status_result(power_reply, "H617A").parsed is not None
+        assert await coordinator.refresh_state(expected_on=True, timeout=0.05)
+        assert coordinator.is_on
+    assert await coordinator.async_refresh_segments(timeout=0.05)
+    assert coordinator._field_revisions["segment_colors"] == 3
+    assert set(coordinator._domain_revisions) == profile.read_domains
+    assert client.write_gatt_char.await_args_list == [call(WRITE_UUID, query, response=False) for query in replies]
 
 
 def test_diy_shapes_expose_painted_flat_and_combo_fields() -> None:

--- a/tests/test_kaitai_protocol.py
+++ b/tests/test_kaitai_protocol.py
@@ -13,8 +13,10 @@ import pytest
 from kaitaistruct import KaitaiStream, KaitaiStructError
 
 from custom_components.ha_govee_led_ble import generated_protocol_adapter
-from custom_components.ha_govee_led_ble.const import MODEL_PROFILES
+from custom_components.ha_govee_led_ble.const import MODEL_PROFILES, UNSUPPORTED_PROFILE, get_profile
 from custom_components.ha_govee_led_ble.coordinator import GoveeBLECoordinator
+from custom_components.ha_govee_led_ble.coordinator_expectations import expectations_from_packet
+from custom_components.ha_govee_led_ble.generated_protocol_adapter import ProtocolParseRejection
 from custom_components.ha_govee_led_ble.transport import xor_checksum
 
 _GENERATED_DIR = os.environ.get("KAITAI_GENERATED_DIR")
@@ -147,6 +149,32 @@ def test_h6199_command_acknowledgement_rejects_unobserved_opcodes() -> None:
     assert generated_protocol_adapter.parse_command_ack_result(bytes(frame), "H6199").parsed is None
 
 
+@pytest.mark.parametrize("grammar", [None, "unknown"])
+@pytest.mark.parametrize("direction", ["command", "status"])
+def test_missing_or_unknown_grammar_fails_closed_only_in_its_direction(monkeypatch, grammar, direction) -> None:
+    monkeypatch.setitem(MODEL_PROFILES, "H617A", replace(MODEL_PROFILES["H617A"], **{f"{direction}_grammar": grammar}))
+    command = generated_protocol_adapter.parse_command_result(COMMAND_STATIC)
+    status = generated_protocol_adapter.parse_status_result(STATUS_SEGMENTS)
+    rejected, accepted = (command, status) if direction == "command" else (status, command)
+    assert rejected.parsed is None and rejected.parser is None
+    assert rejected.rejection is ProtocolParseRejection.UNSUPPORTED_MODEL
+    assert accepted.parsed is not None and accepted.rejection is None
+
+    if direction == "command":
+        assert expectations_from_packet(COMMAND_STATIC) == {}
+        for build, args in (
+            (generated_protocol_adapter.build_power, (True,)),
+            (generated_protocol_adapter.build_brightness_query, ()),
+            (generated_protocol_adapter.build_segment_query, (1,)),
+            (generated_protocol_adapter.build_segment_colour, (1, 10, 20, 30)),
+        ):
+            with pytest.raises(ValueError, match="grammar"):
+                build(*args)
+    else:
+        assert generated_protocol_adapter.build_power(True) == bytes.fromhex("3301010000000000000000000000000000000033")
+        assert generated_protocol_adapter.build_segment_query(5) == H617A_SEGMENT_QUERY
+
+
 def test_command_and_status_fields_are_meaningful() -> None:
     command = _parse(CommandWrite, COMMAND_STATIC)
     assert command.opcode.name == "multi"
@@ -221,18 +249,78 @@ def test_h66a0_four_slot_pages_reach_semantic_observation(hass, monkeypatch) -> 
     parsed._write(output)
     assert output.to_byte_array() == nonzero_final
 
-    # Test-only layout selection exercises real decode/notify/observation without
-    # registering H66A0 or changing the production status dispatcher.
-    profile = replace(MODEL_PROFILES["H617A"], segment_count=14, segment_group_size=4)
-    monkeypatch.setattr("custom_components.ha_govee_led_ble.coordinator.get_profile", lambda _: profile)
-    monkeypatch.setitem(generated_protocol_adapter._STATUS_ROOTS, "H617A", ("h66a0_status_reply", root))
-    coordinator = GoveeBLECoordinator(
-        hass, "AA:BB:CC:DD:EE:FF", "H617A", configuration_url="homeassistant://ha-govee-led-ble/editor/test"
+    # A synthetic exact model reuses outbound H617A bytes and independently selects
+    # the speculative layout. Neither the real H66A0 nor H617A changes support.
+    model = "H7000"
+    status_grammar = "test-h66a0-pages"
+    profile = replace(
+        MODEL_PROFILES["H617A"],
+        name="Synthetic 14-segment device",
+        command_grammar="H617A",
+        status_grammar=status_grammar,
+        segment_count=14,
+        segment_group_size=4,
     )
+    monkeypatch.setitem(MODEL_PROFILES, model, profile)
+    monkeypatch.setitem(generated_protocol_adapter._STATUS_ROOTS, status_grammar, ("h66a0_status_reply", root))
+    coordinator = GoveeBLECoordinator(
+        hass, "AA:BB:CC:DD:EE:FF", model, configuration_url="homeassistant://ha-govee-led-ble/editor/test"
+    )
+    assert coordinator.profile is profile
+    command = generated_protocol_adapter.build_colour_temperature(3600, (255, 203, 141), 0x7FFF, model)
+    assert command == COMMAND_STATIC
+    parsed_command = generated_protocol_adapter.parse_command_result(command, model)
+    assert parsed_command.parser == "command_write" and parsed_command.parsed is not None
+    assert parsed_command.parsed.body.sub_body.static_body.kelvin == 3600
+    assert generated_protocol_adapter.build_segment_query(5, model) == H617A_SEGMENT_QUERY
+    assert generated_protocol_adapter.parse_status_result(first, model).parser == "h66a0_status_reply"
+    assert generated_protocol_adapter.parse_status_result(STATUS_SEGMENTS, "H617A").parsed is not None
+    assert (
+        generated_protocol_adapter.parse_status_result(first, "H617A").rejection
+        is ProtocolParseRejection.SCHEMA_REJECTED
+    )
+    assert get_profile("H66A0") is UNSUPPORTED_PROFILE
+    assert (
+        generated_protocol_adapter.parse_status_result(first, "H66A0").rejection
+        is ProtocolParseRejection.UNSUPPORTED_MODEL
+    )
+    assert (
+        generated_protocol_adapter.parse_command_result(command, "H66A0").rejection
+        is ProtocolParseRejection.UNSUPPORTED_MODEL
+    )
+
     for frame in (final, first, first, third):
         coordinator._notify_callback(None, bytearray(frame))
         assert coordinator.segment_state_source == "initial"
         assert coordinator._field_revisions.get("segment_colors", 0) == 0
+
+    # Reject malformed frames without corrupting the pending four-page observation.
+    before = coordinator._state_snapshot()
+    revisions = dict(coordinator._field_revisions)
+    domains = dict(coordinator._domain_revisions)
+    assert coordinator._segment_query_colors is not None
+    assert coordinator._segment_query_brightness is not None
+    colours = list(coordinator._segment_query_colors)
+    brightness = list(coordinator._segment_query_brightness)
+    invalid_group = first[:2] + b"\x05" + first[3:-1]
+    invalid_group += bytes((xor_checksum(invalid_group),))
+    for frame, rejection in (
+        (first[:-1], ProtocolParseRejection.INVALID_LENGTH),
+        (first[:-1] + bytes((first[-1] ^ 1,)), ProtocolParseRejection.INVALID_CHECKSUM),
+        (invalid_group, ProtocolParseRejection.SCHEMA_REJECTED),
+    ):
+        assert generated_protocol_adapter.parse_status_result(frame, model).rejection is rejection
+        coordinator._notify_callback(None, bytearray(frame))
+        assert coordinator._state_snapshot() == before
+        assert coordinator._field_revisions == revisions
+        assert coordinator._domain_revisions == domains
+        assert coordinator._segment_query_colors == colours
+        assert coordinator._segment_query_brightness == brightness
+        assert coordinator._segment_groups_observed == {1, 3, 4}
+        assert coordinator.segment_colors == [(255, 255, 255)] * 14
+        assert coordinator.segment_brightness == [100] * 14
+        assert coordinator.segment_state_source == "initial"
+        assert coordinator.segment_state_observed_at is None
     coordinator._notify_callback(None, bytearray(second))
     assert coordinator.segment_state_source == "observed"
     assert coordinator.segment_state_observed_at is not None

--- a/tools/ble/kaitai/speculative/synthetic_mixed_status_reply.ksy
+++ b/tools/ble/kaitai/speculative/synthetic_mixed_status_reply.ksy
@@ -1,0 +1,31 @@
+meta:
+  id: synthetic_mixed_status_reply
+  title: Synthetic shared power and four-slot segment status (fixture only)
+  endian: le
+  imports:
+    - /status_reply
+    - /govee_segment_page
+doc: |
+  SPECULATIVE test-only composition for issue #278, not a device protocol claim.
+  Reuses H617A power status with the fixture's 14-segment, four-slot layout.
+  These are the only readable domains of the synthetic integration profile.
+  This does not extend H66A0 evidence or enable any runtime model.
+seq:
+  - id: header
+    contents: [0xaa]
+  - id: domain
+    type: u1
+    enum: status_domain
+  - id: body
+    size: 17
+    type:
+      switch-on: domain
+      cases:
+        'status_domain::power': status_reply::power_body
+        'status_domain::segments': govee_segment_page(14, 4, false)
+  - id: checksum
+    type: u1
+enums:
+  status_domain:
+    0x01: power
+    0xa5: segments


### PR DESCRIPTION
## Summary
- Replace the shared wire identity with independently declared command and status grammars.
- Route builders, queries, command expectations, and status semantics through the appropriate grammar; preserve independent video queries and ACK handling.
- Prove H617A commands coexist with the speculative 14-segment status layout through a test-only profile, without replacing production roots or enabling H66A0 support.
- Preserve existing device capabilities, support claims, and protocol behavior; document declaration ownership.

## Validation
- `make check` passed, including frontend build/unit/browser checks, lint, formatting, type checks, and generated-output verification.
- Python suite: 1,066 passed, 1 skipped. The fixture skipped in the ordinary suite passed separately in all-schema protocol verification.
- Protocol verification: 46 passed.

Closes #278